### PR TITLE
feat: #3 SQLite schema — complete initial migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist/
 # Alembic
 alembic/versions/*.py
 !alembic/versions/.gitkeep
+!alembic/versions/001_initial.py
 
 # Node
 frontend/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Interactive CLI REPL (`uv run weles`) with streaming output and clean `exit`/Ctrl+C handling (#2)
 - System prompt loaded from `src/weles/prompts/system.md` via `resource_path` (#2)
 
-<!-- Issues #3–5 land here as they are merged -->
+- SQLite schema: all 6 tables (`sessions`, `messages`, `profile`, `history`, `preferences`, `settings`) in a single Alembic migration `001_initial` (#3)
+- Default `settings` rows seeded by migration: `follow_up_cadence`, `proactive_surfacing`, `decay_thresholds`, `max_tool_calls_per_turn` (#3)
+- `get_db()` in `src/weles/db/connection.py`; WAL mode enabled, connection cached per-thread (#3)
+
+<!-- Issues #4–5 land here as they are merged -->
 
 ### v0.2 — Personalization
 <!-- Issues #6–12 -->

--- a/alembic/versions/001_initial.py
+++ b/alembic/versions/001_initial.py
@@ -1,0 +1,125 @@
+"""Initial schema
+
+Revision ID: 001_initial
+Revises:
+Create Date: 2026-04-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sessions",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("title", sa.Text, nullable=True),
+        sa.Column("mode", sa.Text, nullable=False, server_default="'general'"),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column(
+            "session_id",
+            sa.Text,
+            sa.ForeignKey("sessions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("role", sa.Text, nullable=False),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("tool_name", sa.Text, nullable=True),
+        sa.Column("is_compressed", sa.Boolean, nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "profile",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("height_cm", sa.Float, nullable=True),
+        sa.Column("weight_kg", sa.Float, nullable=True),
+        sa.Column("build", sa.Text, nullable=True),
+        sa.Column("fitness_level", sa.Text, nullable=True),
+        sa.Column("injury_history", sa.Text, nullable=True),
+        sa.Column("dietary_restrictions", sa.Text, nullable=True),
+        sa.Column("dietary_preferences", sa.Text, nullable=True),
+        sa.Column("dietary_approach", sa.Text, nullable=True),
+        sa.Column("aesthetic_style", sa.Text, nullable=True),
+        sa.Column("brand_rejections", sa.Text, nullable=True),
+        sa.Column("climate", sa.Text, nullable=True),
+        sa.Column("activity_level", sa.Text, nullable=True),
+        sa.Column("living_situation", sa.Text, nullable=True),
+        sa.Column("country", sa.Text, nullable=True),
+        sa.Column("budget_psychology", sa.Text, nullable=True),
+        sa.Column("fitness_goal", sa.Text, nullable=True),
+        sa.Column("dietary_goal", sa.Text, nullable=True),
+        sa.Column("lifestyle_focus", sa.Text, nullable=True),
+        sa.Column("first_session_at", sa.DateTime, nullable=True),
+        sa.Column("field_timestamps", sa.Text, nullable=False, server_default=sa.text("'{}'")),
+    )
+
+    op.create_table(
+        "history",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("item_name", sa.Text, nullable=False),
+        sa.Column("category", sa.Text, nullable=False),
+        sa.Column("domain", sa.Text, nullable=False),
+        sa.Column("status", sa.Text, nullable=False),
+        sa.Column("rating", sa.Integer, nullable=True),
+        sa.Column("notes", sa.Text, nullable=True),
+        sa.Column("follow_up_due_at", sa.DateTime, nullable=True),
+        sa.Column("check_in_due_at", sa.DateTime, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "preferences",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("dimension", sa.Text, nullable=False),
+        sa.Column("value", sa.Text, nullable=False),
+        sa.Column("reason", sa.Text, nullable=True),
+        sa.Column("source", sa.Text, nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "settings",
+        sa.Column("key", sa.Text, primary_key=True),
+        sa.Column("value", sa.Text, nullable=False),
+    )
+
+    settings_table = sa.table(
+        "settings",
+        sa.column("key", sa.Text),
+        sa.column("value", sa.Text),
+    )
+    op.bulk_insert(
+        settings_table,
+        [
+            {"key": "follow_up_cadence", "value": '"off"'},
+            {"key": "proactive_surfacing", "value": '"true"'},
+            {
+                "key": "decay_thresholds",
+                "value": (
+                    '{"goals": 60, "fitness_level": 90, "dietary_approach": 90,'
+                    ' "body_metrics": 180, "taste_lifestyle": 365}'
+                ),
+            },
+            {"key": "max_tool_calls_per_turn", "value": '"6"'},
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("settings")
+    op.drop_table("preferences")
+    op.drop_table("history")
+    op.drop_table("profile")
+    op.drop_table("messages")
+    op.drop_table("sessions")

--- a/src/weles/db/connection.py
+++ b/src/weles/db/connection.py
@@ -9,9 +9,12 @@ _local = threading.local()
 def get_db() -> sqlite3.Connection:
     conn: sqlite3.Connection | None = getattr(_local, "conn", None)
     if conn is None:
-        db_path = os.getenv("WELES_DB_PATH", str(Path.home() / ".weles" / "weles.db"))
-        conn = sqlite3.connect(db_path, check_same_thread=False)
+        raw = os.getenv("WELES_DB_PATH", str(Path.home() / ".weles" / "weles.db"))
+        db_file = Path(raw).expanduser()
+        db_file.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_file), check_same_thread=False)
         conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
         conn.row_factory = sqlite3.Row
         _local.conn = conn
     return conn

--- a/src/weles/db/connection.py
+++ b/src/weles/db/connection.py
@@ -1,0 +1,17 @@
+import os
+import sqlite3
+import threading
+from pathlib import Path
+
+_local = threading.local()
+
+
+def get_db() -> sqlite3.Connection:
+    conn: sqlite3.Connection | None = getattr(_local, "conn", None)
+    if conn is None:
+        db_path = os.getenv("WELES_DB_PATH", str(Path.home() / ".weles" / "weles.db"))
+        conn = sqlite3.connect(db_path, check_same_thread=False)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.row_factory = sqlite3.Row
+        _local.conn = conn
+    return conn

--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -1,0 +1,43 @@
+import json
+import sqlite3
+from pathlib import Path
+
+
+def test_migration_applies_cleanly(tmp_db: Path) -> None:
+    assert tmp_db.exists()
+
+
+def test_all_tables_exist(tmp_db: Path) -> None:
+    conn = sqlite3.connect(tmp_db)
+    tables = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'alembic%'"
+        ).fetchall()
+    }
+    conn.close()
+    assert tables == {"sessions", "messages", "profile", "history", "preferences", "settings"}
+
+
+def test_default_settings_present(tmp_db: Path) -> None:
+    conn = sqlite3.connect(tmp_db)
+    rows = {row[0]: row[1] for row in conn.execute("SELECT key, value FROM settings").fetchall()}
+    conn.close()
+
+    assert rows["follow_up_cadence"] == '"off"'
+    assert rows["proactive_surfacing"] == '"true"'
+    assert rows["max_tool_calls_per_turn"] == '"6"'
+
+    thresholds = json.loads(rows["decay_thresholds"])
+    assert thresholds["goals"] == 60
+    assert thresholds["fitness_level"] == 90
+    assert thresholds["dietary_approach"] == 90
+    assert thresholds["body_metrics"] == 180
+    assert thresholds["taste_lifestyle"] == 365
+
+
+def test_alembic_revision(tmp_db: Path) -> None:
+    conn = sqlite3.connect(tmp_db)
+    revision = conn.execute("SELECT version_num FROM alembic_version").fetchone()[0]
+    conn.close()
+    assert revision == "001_initial"


### PR DESCRIPTION
## Summary

- Single Alembic migration `001_initial` creates all 6 tables with every column specified in the issue
- Default `settings` rows seeded in the migration: `follow_up_cadence`, `proactive_surfacing`, `decay_thresholds`, `max_tool_calls_per_turn`
- `get_db()` returns a WAL-mode SQLite connection cached per-thread via `threading.local()`

## Acceptance criteria

- [x] `alembic.ini` database URL reads `WELES_DB_PATH` env var (already configured in `env.py`)
- [x] Single migration `001_initial.py` with all tables: `sessions`, `messages`, `profile`, `history`, `preferences`, `settings`
- [x] `sessions` — `id`, `title`, `mode` (default `general`), `created_at`
- [x] `messages` — `id`, `session_id` (FK→sessions CASCADE), `role`, `content`, `tool_name`, `is_compressed` (default false), `created_at`
- [x] `profile` — all 21 columns including `first_session_at`, `field_timestamps` (default `{}`)
- [x] `history` — `id`, `item_name`, `category`, `domain`, `status`, `rating`, `notes`, `follow_up_due_at`, `check_in_due_at`, `created_at`
- [x] `preferences` — `id`, `dimension`, `value`, `reason`, `source`, `created_at`
- [x] `settings` — `key` PK, `value`
- [x] Default settings rows inserted by migration
- [x] `src/weles/db/connection.py` — `get_db()` with WAL mode, per-thread cache

## Tests

- [x] `test_migration_applies_cleanly` — fresh DB migrates without error
- [x] `test_all_tables_exist` — all 6 tables verified via `sqlite_master`
- [x] `test_default_settings_present` — correct values for all 4 default rows
- [x] `test_alembic_revision` — `alembic_version` = `001_initial`

## Docs

- [x] `CHANGELOG.md` updated under v0.1 Skeleton

## Notes

`.gitignore` had `alembic/versions/*.py` (to ignore auto-generated migrations). Added `!alembic/versions/001_initial.py` exception since this migration is intentionally committed per A7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)