### PR TITLE
feat: #4 App startup sequence and runtime validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Default `settings` rows seeded by migration: `follow_up_cadence`, `proactive_surfacing`, `decay_thresholds`, `max_tool_calls_per_turn` (#3)
 - `get_db()` in `src/weles/db/connection.py`; WAL mode enabled, connection cached per-thread (#3)
 
-<!-- Issues #4–5 land here as they are merged -->
+- `startup()` coroutine in `src/weles/api/startup.py`; validates env, runs migrations, seeds settings, sets `web_search_available` and `is_first_run` on app state (#4)
+- `GET /health` endpoint; returns `{"status": "ok", "web_search": bool, "first_run": bool}` (#4)
+
+<!-- Issue #5 lands here when merged -->
 
 ### v0.2 — Personalization
 <!-- Issues #6–12 -->

--- a/src/weles/api/main.py
+++ b/src/weles/api/main.py
@@ -1,3 +1,16 @@
 from fastapi import FastAPI
 
 app = FastAPI(title="Weles")
+
+# Defaults before startup() is wired into lifespan (#5)
+app.state.web_search_available = False
+app.state.is_first_run = True
+
+
+@app.get("/health")
+async def health() -> dict[str, object]:
+    return {
+        "status": "ok",
+        "web_search": app.state.web_search_available,
+        "first_run": app.state.is_first_run,
+    }

--- a/src/weles/api/startup.py
+++ b/src/weles/api/startup.py
@@ -9,8 +9,11 @@ from dotenv import load_dotenv
 
 from weles.db.connection import get_db
 from weles.utils.errors import ConfigurationError
+from weles.utils.paths import resource_path
 
 logger = logging.getLogger(__name__)
+
+_WELES_DIR = Path.home() / ".weles"
 
 _DEFAULT_SETTINGS = [
     ("follow_up_cadence", '"off"'),
@@ -43,12 +46,8 @@ def check_port_free() -> None:
 
 async def startup(state: Any) -> None:
     """Initialise app state: validate env, run migrations, seed settings."""
-    # Derive weles dir from WELES_DB_PATH (defaults to ~/.weles)
-    raw_db = os.getenv("WELES_DB_PATH", str(Path.home() / ".weles" / "weles.db"))
-    weles_dir = Path(raw_db).expanduser().parent
-
     # 1. Load ~/.weles/.env if it exists — supplements env, does not override shell
-    env_file = weles_dir / ".env"
+    env_file = _WELES_DIR / ".env"
     if env_file.exists():
         load_dotenv(env_file, override=False)
 
@@ -58,14 +57,17 @@ async def startup(state: Any) -> None:
             "ANTHROPIC_API_KEY is not set. Set it in your environment or ~/.weles/.env."
         )
 
-    # 3. Create weles dir if absent
-    weles_dir.mkdir(parents=True, exist_ok=True)
+    # 3. Create ~/.weles/ if absent
+    _WELES_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Port conflict check — exit before serving if port is already bound
+    check_port_free()
 
     # 4. Run alembic upgrade head
     from alembic import command
     from alembic.config import Config
 
-    cfg = Config("alembic.ini")
+    cfg = Config(str(resource_path("alembic.ini")))
     command.upgrade(cfg, "head")
 
     # 5. Seed default settings if table is empty

--- a/src/weles/api/startup.py
+++ b/src/weles/api/startup.py
@@ -55,8 +55,7 @@ async def startup(state: Any) -> None:
     # 2. Validate ANTHROPIC_API_KEY
     if not os.getenv("ANTHROPIC_API_KEY"):
         raise ConfigurationError(
-            "ANTHROPIC_API_KEY is not set."
-            " Set it in your environment or ~/.weles/.env."
+            "ANTHROPIC_API_KEY is not set. Set it in your environment or ~/.weles/.env."
         )
 
     # 3. Create weles dir if absent

--- a/src/weles/api/startup.py
+++ b/src/weles/api/startup.py
@@ -1,0 +1,88 @@
+import logging
+import os
+import socket
+import sys
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+from weles.db.connection import get_db
+from weles.utils.errors import ConfigurationError
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SETTINGS = [
+    ("follow_up_cadence", '"off"'),
+    ("proactive_surfacing", '"true"'),
+    (
+        "decay_thresholds",
+        '{"goals": 60, "fitness_level": 90, "dietary_approach": 90,'
+        ' "body_metrics": 180, "taste_lifestyle": 365}',
+    ),
+    ("max_tool_calls_per_turn", '"6"'),
+]
+
+
+def check_port_free() -> None:
+    """Exit with a readable message if WELES_PORT is already bound."""
+    port = int(os.getenv("WELES_PORT", "8000"))
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", port))
+    except OSError:
+        print(
+            f"[ERROR] Port {port} is already in use."
+            " Stop the existing Weles process and try again.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    finally:
+        sock.close()
+
+
+async def startup(state: Any) -> None:
+    """Initialise app state: validate env, run migrations, seed settings."""
+    # Derive weles dir from WELES_DB_PATH (defaults to ~/.weles)
+    raw_db = os.getenv("WELES_DB_PATH", str(Path.home() / ".weles" / "weles.db"))
+    weles_dir = Path(raw_db).expanduser().parent
+
+    # 1. Load ~/.weles/.env if it exists — supplements env, does not override shell
+    env_file = weles_dir / ".env"
+    if env_file.exists():
+        load_dotenv(env_file, override=False)
+
+    # 2. Validate ANTHROPIC_API_KEY
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        raise ConfigurationError(
+            "ANTHROPIC_API_KEY is not set."
+            " Set it in your environment or ~/.weles/.env."
+        )
+
+    # 3. Create weles dir if absent
+    weles_dir.mkdir(parents=True, exist_ok=True)
+
+    # 4. Run alembic upgrade head
+    from alembic import command
+    from alembic.config import Config
+
+    cfg = Config("alembic.ini")
+    command.upgrade(cfg, "head")
+
+    # 5. Seed default settings if table is empty
+    conn = get_db()
+    count_row = conn.execute("SELECT COUNT(*) FROM settings").fetchone()
+    if count_row[0] == 0:
+        conn.executemany("INSERT INTO settings (key, value) VALUES (?, ?)", _DEFAULT_SETTINGS)
+        conn.commit()
+
+    # 6. Check TAVILY_API_KEY
+    if os.getenv("TAVILY_API_KEY"):
+        state.web_search_available = True
+    else:
+        logger.warning("[WARN] Tavily key not set — web search disabled")
+        state.web_search_available = False
+
+    # 7. Set is_first_run based on profile.first_session_at
+    profile_row = conn.execute("SELECT first_session_at FROM profile LIMIT 1").fetchone()
+    state.is_first_run = profile_row is None or profile_row[0] is None

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -1,0 +1,80 @@
+import types
+
+import pytest
+from pytest_mock import MockerFixture
+
+from weles.utils.errors import ConfigurationError
+
+
+async def test_startup_raises_without_anthropic_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    from weles.api.startup import startup
+
+    state = types.SimpleNamespace()
+    with pytest.raises(ConfigurationError, match="ANTHROPIC_API_KEY"):
+        await startup(state)
+
+
+async def test_startup_web_search_false_without_tavily(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.fixture, mocker: MockerFixture
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.setenv("WELES_DB_PATH", str(tmp_path / "weles.db"))
+
+    mock_conn = mocker.MagicMock()
+    mock_conn.execute.return_value.fetchone.side_effect = [(4,), None]
+    mocker.patch("weles.api.startup.get_db", return_value=mock_conn)
+    mocker.patch("alembic.command.upgrade")
+
+    from weles.api.startup import startup
+
+    state = types.SimpleNamespace()
+    await startup(state)
+
+    assert state.web_search_available is False
+
+
+async def test_startup_web_search_true_with_tavily(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.fixture, mocker: MockerFixture
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    monkeypatch.setenv("WELES_DB_PATH", str(tmp_path / "weles.db"))
+
+    mock_conn = mocker.MagicMock()
+    mock_conn.execute.return_value.fetchone.side_effect = [(4,), None]
+    mocker.patch("weles.api.startup.get_db", return_value=mock_conn)
+    mocker.patch("alembic.command.upgrade")
+
+    from weles.api.startup import startup
+
+    state = types.SimpleNamespace()
+    await startup(state)
+
+    assert state.web_search_available is True
+
+
+async def test_startup_creates_weles_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.fixture, mocker: MockerFixture
+) -> None:
+    weles_dir = tmp_path / ".weles"
+    db_path = weles_dir / "weles.db"
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    monkeypatch.setenv("WELES_DB_PATH", str(db_path))
+
+    assert not weles_dir.exists()
+
+    mock_conn = mocker.MagicMock()
+    mock_conn.execute.return_value.fetchone.side_effect = [(4,), None]
+    mocker.patch("weles.api.startup.get_db", return_value=mock_conn)
+    mocker.patch("alembic.command.upgrade")
+
+    from weles.api.startup import startup
+
+    state = types.SimpleNamespace()
+    await startup(state)
+
+    assert weles_dir.exists()

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -16,65 +16,76 @@ async def test_startup_raises_without_anthropic_key(monkeypatch: pytest.MonkeyPa
 
 
 async def test_startup_web_search_false_without_tavily(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.fixture, mocker: MockerFixture
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pytest.fixture,
+    mocker: MockerFixture,
 ) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
-    monkeypatch.setenv("WELES_DB_PATH", str(tmp_path / "weles.db"))
 
     mock_conn = mocker.MagicMock()
     mock_conn.execute.return_value.fetchone.side_effect = [(4,), None]
     mocker.patch("weles.api.startup.get_db", return_value=mock_conn)
+    mocker.patch("weles.api.startup.check_port_free")
     mocker.patch("alembic.command.upgrade")
 
-    from weles.api.startup import startup
+    from weles.api import startup as startup_mod
+
+    mocker.patch.object(startup_mod, "_WELES_DIR", tmp_path / ".weles")
 
     state = types.SimpleNamespace()
-    await startup(state)
+    await startup_mod.startup(state)
 
     assert state.web_search_available is False
 
 
 async def test_startup_web_search_true_with_tavily(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.fixture, mocker: MockerFixture
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pytest.fixture,
+    mocker: MockerFixture,
 ) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
-    monkeypatch.setenv("WELES_DB_PATH", str(tmp_path / "weles.db"))
 
     mock_conn = mocker.MagicMock()
     mock_conn.execute.return_value.fetchone.side_effect = [(4,), None]
     mocker.patch("weles.api.startup.get_db", return_value=mock_conn)
+    mocker.patch("weles.api.startup.check_port_free")
     mocker.patch("alembic.command.upgrade")
 
-    from weles.api.startup import startup
+    from weles.api import startup as startup_mod
+
+    mocker.patch.object(startup_mod, "_WELES_DIR", tmp_path / ".weles")
 
     state = types.SimpleNamespace()
-    await startup(state)
+    await startup_mod.startup(state)
 
     assert state.web_search_available is True
 
 
 async def test_startup_creates_weles_dir(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.fixture, mocker: MockerFixture
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pytest.fixture,
+    mocker: MockerFixture,
 ) -> None:
     weles_dir = tmp_path / ".weles"
-    db_path = weles_dir / "weles.db"
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
-    monkeypatch.setenv("WELES_DB_PATH", str(db_path))
 
     assert not weles_dir.exists()
 
     mock_conn = mocker.MagicMock()
     mock_conn.execute.return_value.fetchone.side_effect = [(4,), None]
     mocker.patch("weles.api.startup.get_db", return_value=mock_conn)
+    mocker.patch("weles.api.startup.check_port_free")
     mocker.patch("alembic.command.upgrade")
 
-    from weles.api.startup import startup
+    from weles.api import startup as startup_mod
+
+    mocker.patch.object(startup_mod, "_WELES_DIR", weles_dir)
 
     state = types.SimpleNamespace()
-    await startup(state)
+    await startup_mod.startup(state)
 
     assert weles_dir.exists()


### PR DESCRIPTION
## Issue

Closes #4

## What this PR does

Adds `startup()` coroutine with env validation, alembic migration, settings seeding, and app state initialisation, plus `GET /health`.

## Acceptance criteria

- [x] `startup()` async coroutine in `src/weles/api/startup.py`
- [x] Loads `~/.weles/.env` if it exists (supplements env, does not override shell env)
- [x] Validates `ANTHROPIC_API_KEY` — raises `ConfigurationError` with clear message if missing
- [x] Creates `~/.weles/` directory if absent
- [x] Runs `alembic upgrade head` programmatically
- [x] Seeds default `settings` rows if table is empty
- [x] Checks `TAVILY_API_KEY` — sets `web_search_available` on app state; logs warning if absent
- [x] Queries `profile.first_session_at IS NULL` — sets `is_first_run` on app state
- [x] `check_port_free()` helper exits with readable message if `WELES_PORT` already bound
- [x] `GET /health` returns `{"status": "ok", "web_search": bool, "first_run": bool}`

## Tests

- [x] All tests specified in the issue are present
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (if endpoints changed)
- [ ] `docs/architecture.md` updated (if patterns or module boundaries changed)

## Notes

`GET /health` is the only new endpoint; `docs/api.md` will be introduced in #5 when the full API surface lands. `startup()` is not yet wired into FastAPI lifespan — that happens in #5.