### PR TITLE
feat: #5 FastAPI backend and React chat UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `startup()` coroutine in `src/weles/api/startup.py`; validates env, runs migrations, seeds settings, sets `web_search_available` and `is_first_run` on app state (#4)
 - `GET /health` endpoint; returns `{"status": "ok", "web_search": bool, "first_run": bool}` (#4)
 
-<!-- Issue #5 lands here when merged -->
+- FastAPI app with full REST API: sessions, messages, profile, history, settings, preferences, data endpoints (#5)
+- SSE streaming on `POST /sessions/{id}/messages`; typed events: `text_delta`, `tool_start`, `tool_end`, `tool_error`, `done`, `error` (#5)
+- React + Vite chat UI: sidebar session list, mode selector pill tabs, streaming markdown rendering, tool-use progress strip, settings page (#5)
+- `uv run weles` now starts the FastAPI server; CLI REPL removed (#5)
+- `DELETE /data` wipes and recreates all tables via alembic downgrade + upgrade (#5)
 
 ### v0.2 — Personalization
 <!-- Issues #6–12 -->

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -863,18 +865,59 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -891,7 +934,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -906,6 +948,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.1",
@@ -1202,6 +1250,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -1290,6 +1344,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1387,6 +1451,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1402,6 +1476,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/color-convert": {
@@ -1423,6 +1537,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1457,14 +1581,12 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1478,12 +1600,34 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1493,6 +1637,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1699,6 +1856,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1708,6 +1875,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1860,6 +2033,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -1875,6 +2088,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -1914,6 +2137,46 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1935,6 +2198,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -2319,6 +2604,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2328,6 +2623,861 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -2346,7 +3496,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2445,6 +3594,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2524,6 +3698,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2553,6 +3737,99 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve-from": {
@@ -2655,6 +3932,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2666,6 +3967,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/supports-color": {
@@ -2696,6 +4015,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2777,6 +4116,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2816,6 +4242,34 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -2963,6 +4417,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,184 +1,229 @@
-.counter {
-  font-size: 16px;
-  padding: 5px 10px;
-  border-radius: 5px;
-  color: var(--accent);
-  background: var(--accent-bg);
-  border: 2px solid transparent;
-  transition: border-color 0.3s;
-  margin-bottom: 24px;
+* { box-sizing: border-box; margin: 0; padding: 0; }
 
-  &:hover {
-    border-color: var(--accent-border);
-  }
-  &:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f0f0f;
+  color: #e8e8e8;
+  height: 100vh;
+  overflow: hidden;
 }
 
-.hero {
-  position: relative;
-
-  .base,
-  .framework,
-  .vite {
-    inset-inline: 0;
-    margin: 0 auto;
-  }
-
-  .base {
-    width: 170px;
-    position: relative;
-    z-index: 0;
-  }
-
-  .framework,
-  .vite {
-    position: absolute;
-  }
-
-  .framework {
-    z-index: 1;
-    top: 34px;
-    height: 28px;
-    transform: perspective(2000px) rotateZ(300deg) rotateX(44deg) rotateY(39deg)
-      scale(1.4);
-  }
-
-  .vite {
-    z-index: 0;
-    top: 107px;
-    height: 26px;
-    width: auto;
-    transform: perspective(2000px) rotateZ(300deg) rotateX(40deg) rotateY(39deg)
-      scale(0.8);
-  }
+.layout {
+  display: flex;
+  height: 100vh;
 }
 
-#center {
+/* ── Sidebar ── */
+.sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  background: #1a1a1a;
+  border-right: 1px solid #2e2e2e;
   display: flex;
   flex-direction: column;
-  gap: 25px;
-  place-content: center;
-  place-items: center;
-  flex-grow: 1;
-
-  @media (max-width: 1024px) {
-    padding: 32px 20px 24px;
-    gap: 18px;
-  }
+  padding: 12px 8px;
+  gap: 8px;
 }
 
-#next-steps {
-  display: flex;
-  border-top: 1px solid var(--border);
+.new-chat-btn {
+  background: #2a2a2a;
+  color: #e8e8e8;
+  border: 1px solid #3a3a3a;
+  border-radius: 6px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
   text-align: left;
+}
+.new-chat-btn:hover { background: #333; }
 
-  & > div {
-    flex: 1 1 0;
-    padding: 32px;
-    @media (max-width: 1024px) {
-      padding: 24px 20px;
-    }
-  }
-
-  .icon {
-    margin-bottom: 16px;
-    width: 22px;
-    height: 22px;
-  }
-
-  @media (max-width: 1024px) {
-    flex-direction: column;
-    text-align: center;
-  }
+.session-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
-#docs {
-  border-right: 1px solid var(--border);
+.session-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 8px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #aaa;
+}
+.session-item:hover { background: #222; color: #e8e8e8; }
+.session-item.active { background: #252525; color: #e8e8e8; }
 
-  @media (max-width: 1024px) {
-    border-right: none;
-    border-bottom: 1px solid var(--border);
-  }
+.session-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
 }
 
-#next-steps ul {
-  list-style: none;
-  padding: 0;
+.del-btn {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.del-btn:hover { color: #e8e8e8; }
+
+.sidebar-links {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-top: 1px solid #2e2e2e;
+  padding-top: 8px;
+}
+.sidebar-links button {
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  text-align: left;
+  padding: 6px 8px;
+  border-radius: 5px;
+  font-size: 13px;
+}
+.sidebar-links button:hover { background: #222; color: #e8e8e8; }
+
+/* ── Chat area ── */
+.chat-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.mode-bar {
+  display: flex;
+  gap: 6px;
+  padding: 10px 16px;
+  border-bottom: 1px solid #2e2e2e;
+  background: #141414;
+}
+
+.mode-pill {
+  background: #222;
+  border: 1px solid #333;
+  color: #999;
+  border-radius: 20px;
+  padding: 4px 14px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.mode-pill:hover { background: #2a2a2a; color: #e8e8e8; }
+.mode-pill.active { background: #3a3a3a; color: #e8e8e8; border-color: #555; }
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.message { display: flex; }
+.message.user { justify-content: flex-end; }
+.message.assistant { justify-content: flex-start; }
+
+.bubble {
+  max-width: 70%;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.message.user .bubble { background: #2a4a7a; color: #e8e8e8; }
+.message.assistant .bubble { background: #1e1e1e; color: #e8e8e8; }
+
+.bubble p { margin: 0 0 6px; }
+.bubble p:last-child { margin-bottom: 0; }
+.bubble code { background: #2a2a2a; padding: 1px 4px; border-radius: 3px; font-size: 13px; }
+.bubble pre { background: #1a1a1a; padding: 10px; border-radius: 6px; overflow-x: auto; }
+.bubble ul, .bubble ol { padding-left: 18px; }
+
+/* ── Tool strip ── */
+.tool-strip {
+  border-top: 1px solid #2e2e2e;
+  background: #141414;
+  padding: 6px 16px;
+  font-size: 12px;
+  color: #888;
+  cursor: pointer;
+}
+.tool-strip:hover { background: #1a1a1a; }
+.tool-strip.expanded { max-height: 200px; overflow-y: auto; }
+.tool-line { padding: 2px 0; }
+.tool-line.status-error { color: #c8963a; }
+.tool-line.status-done { color: #666; }
+.tool-line.status-running { color: #aaa; }
+
+/* ── Input bar ── */
+.input-bar {
   display: flex;
   gap: 8px;
-  margin: 32px 0 0;
-
-  .logo {
-    height: 18px;
-  }
-
-  a {
-    color: var(--text-h);
-    font-size: 16px;
-    border-radius: 6px;
-    background: var(--social-bg);
-    display: flex;
-    padding: 6px 12px;
-    align-items: center;
-    gap: 8px;
-    text-decoration: none;
-    transition: box-shadow 0.3s;
-
-    &:hover {
-      box-shadow: var(--shadow);
-    }
-    .button-icon {
-      height: 18px;
-      width: 18px;
-    }
-  }
-
-  @media (max-width: 1024px) {
-    margin-top: 20px;
-    flex-wrap: wrap;
-    justify-content: center;
-
-    li {
-      flex: 1 1 calc(50% - 8px);
-    }
-
-    a {
-      width: 100%;
-      justify-content: center;
-      box-sizing: border-box;
-    }
-  }
+  padding: 12px 16px;
+  border-top: 1px solid #2e2e2e;
+  background: #141414;
 }
-
-#spacer {
-  height: 88px;
-  border-top: 1px solid var(--border);
-  @media (max-width: 1024px) {
-    height: 48px;
-  }
+.input-bar textarea {
+  flex: 1;
+  background: #1e1e1e;
+  border: 1px solid #333;
+  color: #e8e8e8;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 14px;
+  resize: none;
+  font-family: inherit;
+  line-height: 1.4;
+  max-height: 200px;
 }
-
-.ticks {
-  position: relative;
-  width: 100%;
-
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    top: -4.5px;
-    border: 5px solid transparent;
-  }
-
-  &::before {
-    left: 0;
-    border-left-color: var(--border);
-  }
-  &::after {
-    right: 0;
-    border-right-color: var(--border);
-  }
+.input-bar textarea:focus { outline: none; border-color: #555; }
+.input-bar button {
+  background: #2a4a7a;
+  color: #e8e8e8;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 18px;
+  font-size: 14px;
+  cursor: pointer;
+  align-self: flex-end;
 }
+.input-bar button:hover { background: #3a5a8a; }
+.input-bar button:disabled { opacity: 0.4; cursor: default; }
+
+/* ── Settings page ── */
+.settings-page { max-width: 600px; margin: 40px auto; padding: 0 24px; }
+.settings-page h1 { margin-bottom: 24px; }
+.settings-page h2 { font-size: 15px; color: #aaa; margin-bottom: 12px; }
+.settings-page section { margin-bottom: 32px; border-bottom: 1px solid #2e2e2e; padding-bottom: 24px; }
+.settings-page label { display: flex; align-items: center; gap: 10px; font-size: 14px; margin-bottom: 8px; }
+.settings-page select, .settings-page input[type=number] {
+  background: #1e1e1e;
+  border: 1px solid #333;
+  color: #e8e8e8;
+  border-radius: 5px;
+  padding: 4px 8px;
+  font-size: 13px;
+}
+.back-btn { background: none; border: none; color: #888; cursor: pointer; font-size: 14px; margin-bottom: 16px; padding: 0; }
+.back-btn:hover { color: #e8e8e8; }
+.danger-btn { background: #5a2020; color: #e8e8e8; border: none; border-radius: 6px; padding: 8px 16px; font-size: 14px; cursor: pointer; }
+.danger-btn:hover { background: #6a2525; }
+.confirm-modal { background: #1e1e1e; border: 1px solid #3a3a3a; border-radius: 8px; padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+.confirm-modal p { font-size: 14px; color: #aaa; }
+.confirm-modal button { background: #2a2a2a; border: 1px solid #3a3a3a; color: #e8e8e8; border-radius: 5px; padding: 6px 14px; cursor: pointer; font-size: 13px; align-self: flex-start; }
+.confirm-modal button:first-of-type { background: #5a2020; border-color: #6a2525; }
+.cleared-notice { color: #6a9; font-size: 13px; margin-bottom: 8px; }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,121 +1,356 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from './assets/vite.svg'
-import heroImg from './assets/hero.png'
+import { useEffect, useRef, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { clearData, createSession, deleteSession, getSettings, listSessions, patchSession, patchSettings } from './api'
+import type { ChatMessage, Mode, Session, ToolProgress } from './types'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
+const MODES: Mode[] = ['general', 'shopping', 'diet', 'fitness', 'lifestyle']
+const MODE_LABELS: Record<Mode, string> = {
+  general: 'General',
+  shopping: 'Shopping',
+  diet: 'Diet',
+  fitness: 'Fitness',
+  lifestyle: 'Lifestyle',
+}
+
+// ── Settings page ────────────────────────────────────────────────────────────
+
+function SettingsPage({ onBack }: { onBack: () => void }) {
+  const [settings, setSettings] = useState<Record<string, unknown>>({})
+  const [confirmClear, setConfirmClear] = useState(false)
+  const [cleared, setCleared] = useState(false)
+
+  useEffect(() => {
+    getSettings().then(setSettings)
+  }, [])
+
+  async function save(patch: Record<string, unknown>) {
+    const updated = await patchSettings(patch)
+    setSettings(updated)
+  }
+
+  async function handleClearData() {
+    await clearData()
+    setConfirmClear(false)
+    setCleared(true)
+  }
+
+  const decayThresholds = (settings.decay_thresholds as Record<string, number>) ?? {}
 
   return (
-    <>
-      <section id="center">
-        <div className="hero">
-          <img src={heroImg} className="base" width="170" height="179" alt="" />
-          <img src={reactLogo} className="framework" alt="React logo" />
-          <img src={viteLogo} className="vite" alt="Vite logo" />
-        </div>
-        <div>
-          <h1>Get started</h1>
-          <p>
-            Edit <code>src/App.tsx</code> and save to test <code>HMR</code>
-          </p>
-        </div>
-        <button
-          className="counter"
-          onClick={() => setCount((count) => count + 1)}
-        >
-          Count is {count}
-        </button>
+    <div className="settings-page">
+      <button className="back-btn" onClick={onBack}>← Back</button>
+      <h1>Settings</h1>
+
+      <section>
+        <h2>Notifications</h2>
+        <label>
+          Follow-up cadence
+          <select
+            value={String(settings.follow_up_cadence ?? 'off')}
+            onChange={e => save({ follow_up_cadence: e.target.value })}
+          >
+            <option value="off">Off</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+        </label>
       </section>
 
-      <div className="ticks"></div>
-
-      <section id="next-steps">
-        <div id="docs">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
-          </svg>
-          <h2>Documentation</h2>
-          <p>Your questions, answered</p>
-          <ul>
-            <li>
-              <a href="https://vite.dev/" target="_blank" rel="noopener noreferrer">
-                <img className="logo" src={viteLogo} alt="" />
-                Explore Vite
-              </a>
-            </li>
-            <li>
-              <a href="https://react.dev/" target="_blank" rel="noopener noreferrer">
-                <img className="button-icon" src={reactLogo} alt="" />
-                Learn more
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div id="social">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
-          </svg>
-          <h2>Connect with us</h2>
-          <p>Join the Vite community</p>
-          <ul>
-            <li>
-              <a href="https://github.com/vitejs/vite" target="_blank" rel="noopener noreferrer">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#github-icon"></use>
-                </svg>
-                GitHub
-              </a>
-            </li>
-            <li>
-              <a href="https://chat.vite.dev/" target="_blank" rel="noopener noreferrer">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#discord-icon"></use>
-                </svg>
-                Discord
-              </a>
-            </li>
-            <li>
-              <a href="https://x.com/vite_js" target="_blank" rel="noopener noreferrer">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#x-icon"></use>
-                </svg>
-                X.com
-              </a>
-            </li>
-            <li>
-              <a href="https://bsky.app/profile/vite.dev" target="_blank" rel="noopener noreferrer">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#bluesky-icon"></use>
-                </svg>
-                Bluesky
-              </a>
-            </li>
-          </ul>
-        </div>
+      <section>
+        <h2>Proactive surfacing</h2>
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.proactive_surfacing === 'true' || settings.proactive_surfacing === true}
+            onChange={e => save({ proactive_surfacing: String(e.target.checked) })}
+          />
+          Suggest relevant information proactively
+        </label>
       </section>
 
-      <div className="ticks"></div>
-      <section id="spacer"></section>
-    </>
+      <section>
+        <h2>Profile decay thresholds (days)</h2>
+        {Object.entries(decayThresholds).map(([key, val]) => (
+          <label key={key}>
+            {key}
+            <input
+              type="number"
+              value={val}
+              onChange={e =>
+                save({ decay_thresholds: { ...decayThresholds, [key]: Number(e.target.value) } })
+              }
+            />
+          </label>
+        ))}
+      </section>
+
+      <section>
+        <h2>Data</h2>
+        {cleared && <p className="cleared-notice">All data cleared.</p>}
+        {confirmClear ? (
+          <div className="confirm-modal">
+            <p>This will delete all sessions, history, profile, and preferences. Cannot be undone.</p>
+            <button onClick={handleClearData}>Confirm</button>
+            <button onClick={() => setConfirmClear(false)}>Cancel</button>
+          </div>
+        ) : (
+          <button className="danger-btn" onClick={() => setConfirmClear(true)}>Clear all data</button>
+        )}
+      </section>
+    </div>
   )
 }
 
-export default App
+// ── Chat page ────────────────────────────────────────────────────────────────
+
+export default function App() {
+  const [sessions, setSessions] = useState<Session[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const [streaming, setStreaming] = useState(false)
+  const [toolProgress, setToolProgress] = useState<ToolProgress[]>([])
+  const [toolsExpanded, setToolsExpanded] = useState(false)
+  const [page, setPage] = useState<'chat' | 'settings' | 'info'>('chat')
+  const [mode, setMode] = useState<Mode>('general')
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    listSessions().then(setSessions)
+  }, [])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  async function newChat() {
+    const session = await createSession()
+    setSessions(prev => [session, ...prev])
+    setActiveId(session.id)
+    setMessages(
+      session.session_start_prompt
+        ? [{ id: 'init', role: 'assistant', content: session.session_start_prompt }]
+        : []
+    )
+    setToolProgress([])
+    setMode('general')
+    setPage('chat')
+  }
+
+  async function selectSession(id: string) {
+    setActiveId(id)
+    setPage('chat')
+    const r = await fetch(`/sessions/${id}/messages`)
+    const msgs = await r.json()
+    setMessages(
+      msgs
+        .filter((m: { role: string }) => m.role === 'user' || m.role === 'assistant')
+        .map((m: { id: string; role: string; content: string }) => ({
+          id: m.id,
+          role: m.role as 'user' | 'assistant',
+          content: m.content,
+        }))
+    )
+    const sess = sessions.find(s => s.id === id)
+    if (sess) setMode(sess.mode as Mode)
+    setToolProgress([])
+  }
+
+  async function removeSession(id: string, e: React.MouseEvent) {
+    e.stopPropagation()
+    await deleteSession(id)
+    setSessions(prev => prev.filter(s => s.id !== id))
+    if (activeId === id) {
+      setActiveId(null)
+      setMessages([])
+    }
+  }
+
+  async function changeMode(newMode: Mode) {
+    setMode(newMode)
+    if (activeId) {
+      await patchSession(activeId, { mode: newMode })
+      setSessions(prev => prev.map(s => s.id === activeId ? { ...s, mode: newMode } : s))
+    }
+  }
+
+  async function sendMessage() {
+    if (!input.trim() || streaming) return
+    if (!activeId) await newChat()
+    const sessionId = activeId!
+
+    const userMsg: ChatMessage = { id: Date.now().toString(), role: 'user', content: input.trim() }
+    setMessages(prev => [...prev, userMsg])
+    setInput('')
+    setStreaming(true)
+    setToolProgress([])
+
+    const assistantId = `a-${Date.now()}`
+    setMessages(prev => [...prev, { id: assistantId, role: 'assistant', content: '', streaming: true }])
+
+    const resp = await fetch(`/sessions/${sessionId}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: userMsg.content }),
+    })
+
+    if (!resp.body) {
+      setStreaming(false)
+      return
+    }
+
+    const reader = resp.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let currentEvent = ''
+
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (line.startsWith('event:')) {
+          currentEvent = line.slice(6).trim()
+        } else if (line.startsWith('data:')) {
+          const payload = JSON.parse(line.slice(5).trim())
+          if (currentEvent === 'text_delta') {
+            setMessages(prev =>
+              prev.map(m =>
+                m.id === assistantId ? { ...m, content: m.content + payload.delta } : m
+              )
+            )
+          } else if (currentEvent === 'tool_start') {
+            setToolProgress(prev => [...prev, { tool: payload.tool, status: 'running', description: payload.description }])
+          } else if (currentEvent === 'tool_end') {
+            setToolProgress(prev =>
+              prev.map(t => t.tool === payload.tool ? { ...t, status: 'done', summary: payload.result_summary } : t)
+            )
+          } else if (currentEvent === 'tool_error') {
+            setToolProgress(prev =>
+              prev.map(t => t.tool === payload.tool ? { ...t, status: 'error', error: payload.error } : t)
+            )
+          } else if (currentEvent === 'done') {
+            setMessages(prev => prev.map(m => m.id === assistantId ? { ...m, streaming: false } : m))
+            setSessions(prev => prev.map(s => s.id === sessionId ? { ...s, title: payload.title } : s))
+          } else if (currentEvent === 'error') {
+            setMessages(prev =>
+              prev.map(m =>
+                m.id === assistantId
+                  ? { ...m, content: 'Could not reach Claude. Check your API key.', streaming: false }
+                  : m
+              )
+            )
+          }
+        }
+      }
+    }
+
+    setStreaming(false)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+    } else if (e.key === 'Escape') {
+      setInput('')
+    }
+  }
+
+  if (page === 'settings') {
+    return <SettingsPage onBack={() => setPage('chat')} />
+  }
+
+  return (
+    <div className="layout">
+      {/* Sidebar */}
+      <aside className="sidebar">
+        <button className="new-chat-btn" onClick={newChat}>+ New chat</button>
+        <nav className="session-list">
+          {sessions.map(s => (
+            <div
+              key={s.id}
+              className={`session-item${s.id === activeId ? ' active' : ''}`}
+              onClick={() => selectSession(s.id)}
+            >
+              <span className="session-title">{s.title ?? s.preview ?? 'New chat'}</span>
+              <button className="del-btn" onClick={e => removeSession(s.id, e)}>×</button>
+            </div>
+          ))}
+        </nav>
+        <div className="sidebar-links">
+          <button onClick={() => setPage('info')}>Information</button>
+          <button onClick={() => setPage('settings')}>Settings</button>
+        </div>
+      </aside>
+
+      {/* Main */}
+      <main className="chat-area">
+        {/* Mode selector */}
+        <header className="mode-bar">
+          {MODES.map(m => (
+            <button
+              key={m}
+              className={`mode-pill${mode === m ? ' active' : ''}`}
+              onClick={() => changeMode(m)}
+            >
+              {MODE_LABELS[m]}
+            </button>
+          ))}
+        </header>
+
+        {/* Messages */}
+        <div className="messages">
+          {messages.map(msg => (
+            <div key={msg.id} className={`message ${msg.role}`}>
+              <div className="bubble">
+                {msg.role === 'assistant'
+                  ? <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content || (msg.streaming ? '…' : '')}</ReactMarkdown>
+                  : msg.content}
+              </div>
+            </div>
+          ))}
+          <div ref={bottomRef} />
+        </div>
+
+        {/* Tool progress strip */}
+        {toolProgress.length > 0 && (
+          <div className={`tool-strip${toolsExpanded ? ' expanded' : ''}`} onClick={() => setToolsExpanded(p => !p)}>
+            {toolsExpanded
+              ? toolProgress.map((t, i) => (
+                  <div key={i} className={`tool-line status-${t.status}`}>
+                    {t.status === 'error'
+                      ? `⚠ ${t.tool} failed — ${t.error}`
+                      : t.status === 'done'
+                      ? `✓ ${t.tool}: ${t.summary}`
+                      : `⋯ ${t.description ?? t.tool}`}
+                  </div>
+                ))
+              : <span className="tool-summary">{toolProgress.length} tool{toolProgress.length > 1 ? 's' : ''} used — click to expand</span>
+            }
+          </div>
+        )}
+
+        {/* Input */}
+        <div className="input-bar">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Message Weles… (Enter to send, Shift+Enter for newline)"
+            rows={1}
+            disabled={streaming}
+          />
+          <button onClick={sendMessage} disabled={streaming || !input.trim()}>Send</button>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -126,7 +126,7 @@ export default function App() {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
-  async function newChat() {
+  async function newChat(): Promise<string> {
     const session = await createSession()
     setSessions(prev => [session, ...prev])
     setActiveId(session.id)
@@ -138,6 +138,7 @@ export default function App() {
     setToolProgress([])
     setMode('general')
     setPage('chat')
+    return session.id
   }
 
   async function selectSession(id: string) {
@@ -179,8 +180,7 @@ export default function App() {
 
   async function sendMessage() {
     if (!input.trim() || streaming) return
-    if (!activeId) await newChat()
-    const sessionId = activeId!
+    const sessionId = activeId ?? await newChat()
 
     const userMsg: ChatMessage = { id: Date.now().toString(), role: 'user', content: input.trim() }
     setMessages(prev => [...prev, userMsg])

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,42 @@
+import type { Mode, Session } from './types'
+
+export async function createSession(): Promise<Session> {
+  const r = await fetch('/sessions', { method: 'POST' })
+  return r.json()
+}
+
+export async function listSessions(): Promise<Session[]> {
+  const r = await fetch('/sessions')
+  return r.json()
+}
+
+export async function deleteSession(id: string): Promise<void> {
+  await fetch(`/sessions/${id}`, { method: 'DELETE' })
+}
+
+export async function patchSession(id: string, patch: { title?: string; mode?: Mode }): Promise<Session> {
+  const r = await fetch(`/sessions/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+  return r.json()
+}
+
+export async function getSettings(): Promise<Record<string, unknown>> {
+  const r = await fetch('/settings')
+  return r.json()
+}
+
+export async function patchSettings(patch: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const r = await fetch('/settings', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+  return r.json()
+}
+
+export async function clearData(): Promise<void> {
+  await fetch('/data', { method: 'DELETE' })
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,33 @@
+export type Mode = 'general' | 'shopping' | 'diet' | 'fitness' | 'lifestyle'
+
+export interface Session {
+  id: string
+  title: string | null
+  mode: Mode
+  created_at: string
+  preview: string | null
+  session_start_prompt?: string | null
+}
+
+export interface Message {
+  id: string
+  session_id: string
+  role: 'user' | 'assistant'
+  content: string
+  created_at: string
+}
+
+export interface ToolProgress {
+  tool: string
+  status: 'running' | 'done' | 'error'
+  description?: string
+  summary?: string
+  error?: string
+}
+
+export interface ChatMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  streaming?: boolean
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/sessions': 'http://localhost:8000',
+      '/profile': 'http://localhost:8000',
+      '/history': 'http://localhost:8000',
+      '/settings': 'http://localhost:8000',
+      '/preferences': 'http://localhost:8000',
+      '/data': 'http://localhost:8000',
+      '/health': 'http://localhost:8000',
+    },
+  },
 })

--- a/src/weles/__main__.py
+++ b/src/weles/__main__.py
@@ -1,52 +1,22 @@
-import asyncio
-import sys
-
-
-async def _repl() -> None:
-    from weles.agent.client import get_client
-    from weles.agent.prompts import build_system_prompt
-    from weles.agent.session import Session
-    from weles.agent.stream import DoneEvent, TextDeltaEvent, stream_response
-
-    client = get_client()
-    session = Session()
-    system = build_system_prompt("general", None)
-
-    while True:
-        try:
-            user_input = input("You: ").strip()
-        except (EOFError, KeyboardInterrupt):
-            print()
-            break
-
-        if user_input.lower() == "exit":
-            break
-
-        if not user_input:
-            continue
-
-        session.add_message("user", user_input)
-
-        print("Weles: ", end="", flush=True)
-        reply_parts: list[str] = []
-        async for event in stream_response(client, session.get_messages(), [], system):
-            if isinstance(event, TextDeltaEvent):
-                print(event.text, end="", flush=True)
-                reply_parts.append(event.text)
-            elif isinstance(event, DoneEvent):
-                print()
-        if reply_parts:
-            session.add_message("assistant", "".join(reply_parts))
+import os
 
 
 def main() -> None:
-    from weles.utils.errors import ConfigurationError
+    import uvicorn
 
-    try:
-        asyncio.run(_repl())
-    except ConfigurationError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    from weles.api.startup import check_port_free
+
+    check_port_free()
+
+    port = int(os.getenv("WELES_PORT", "8000"))
+    reload = os.getenv("WELES_ENV", "development") == "development"
+    uvicorn.run(
+        "weles.api.main:app",
+        host="127.0.0.1",
+        port=port,
+        reload=reload,
+        log_level="info",
+    )
 
 
 if __name__ == "__main__":

--- a/src/weles/api/main.py
+++ b/src/weles/api/main.py
@@ -1,10 +1,41 @@
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
-app = FastAPI(title="Weles")
+from weles.api.routers import data, history, messages, preferences, profile, sessions, settings
 
-# Defaults before startup() is wired into lifespan (#5)
-app.state.web_search_available = False
-app.state.is_first_run = True
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    from weles.api.startup import startup
+
+    await startup(app.state)
+    yield
+
+
+app = FastAPI(title="Weles", lifespan=lifespan)
+
+# CORS — dev only (same-origin in production)
+if os.getenv("WELES_ENV", "development") == "development":
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+app.include_router(sessions.router)
+app.include_router(messages.router)
+app.include_router(profile.router)
+app.include_router(history.router)
+app.include_router(settings.router)
+app.include_router(data.router)
+app.include_router(preferences.router)
 
 
 @app.get("/health")
@@ -14,3 +45,9 @@ async def health() -> dict[str, object]:
         "web_search": app.state.web_search_available,
         "first_run": app.state.is_first_run,
     }
+
+
+# Serve built frontend in production
+_dist = Path(__file__).parent.parent.parent.parent / "frontend" / "dist"
+if _dist.exists():
+    app.mount("/", StaticFiles(directory=str(_dist), html=True), name="static")

--- a/src/weles/api/routers/data.py
+++ b/src/weles/api/routers/data.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+from fastapi.responses import Response
+
+router = APIRouter(tags=["data"])
+
+
+@router.delete("/data", status_code=204)
+async def clear_data() -> Response:
+    from alembic import command
+    from alembic.config import Config
+
+    from weles.utils.paths import resource_path
+
+    cfg = Config(str(resource_path("alembic.ini")))
+    command.downgrade(cfg, "base")
+    command.upgrade(cfg, "head")
+    return Response(status_code=204)

--- a/src/weles/api/routers/history.py
+++ b/src/weles/api/routers/history.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from weles.db.history_repo import delete_history_item, get_history
+
+router = APIRouter(tags=["history"])
+
+
+@router.get("/history")
+async def list_history(
+    domain: str | None = None, status: str | None = None
+) -> list[dict[str, Any]]:
+    return get_history(domain=domain, status=status)
+
+
+@router.delete("/history/{item_id}", status_code=204)
+async def delete_history(item_id: str) -> None:
+    if not delete_history_item(item_id):
+        raise HTTPException(status_code=404, detail="History item not found")

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -1,0 +1,160 @@
+import json
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+from sse_starlette.sse import EventSourceResponse
+
+from weles.agent.client import get_client
+from weles.agent.dispatch import ToolRegistry
+from weles.agent.prompts import build_system_prompt
+from weles.agent.stream import (
+    AgentEvent,
+    DoneEvent,
+    TextDeltaEvent,
+    ToolEndEvent,
+    ToolErrorEvent,
+    ToolStartEvent,
+    stream_response,
+)
+from weles.db.connection import get_db
+from weles.db.profile_repo import set_first_session_at
+from weles.utils.errors import ConfigurationError
+
+router = APIRouter(tags=["messages"])
+
+
+class MessageBody(BaseModel):
+    content: str
+
+
+def _get_session(session_id: str) -> dict[str, Any]:
+    conn = get_db()
+    row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return dict(row)
+
+
+def _load_history(session_id: str) -> list[dict[str, Any]]:
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT role, content FROM messages WHERE session_id = ? ORDER BY created_at ASC",
+        (session_id,),
+    ).fetchall()
+    return [{"role": row["role"], "content": row["content"]} for row in rows]
+
+
+def _save_message(session_id: str, role: str, content: str, tool_name: str | None = None) -> None:
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, content, tool_name, is_compressed, created_at)"
+        " VALUES (?, ?, ?, ?, ?, 0, ?)",
+        (str(uuid.uuid4()), session_id, role, content, tool_name, datetime.utcnow()),
+    )
+    conn.commit()
+
+
+def _set_session_title(session_id: str, content: str) -> None:
+    conn = get_db()
+    existing = conn.execute("SELECT title FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    if existing and existing["title"] is None:
+        title = content[:50]
+        conn.execute("UPDATE sessions SET title = ? WHERE id = ?", (title, session_id))
+        conn.commit()
+
+
+def _is_first_message(session_id: str) -> bool:
+    conn = get_db()
+    row = conn.execute(
+        "SELECT id FROM messages WHERE session_id = ? AND role = 'user' LIMIT 1",
+        (session_id,),
+    ).fetchone()
+    return row is None
+
+
+@router.post("/sessions/{session_id}/messages")
+async def post_message(session_id: str, body: MessageBody, request: Request) -> EventSourceResponse:
+    _get_session(session_id)
+
+    async def event_stream() -> AsyncIterator[dict[str, Any]]:
+        is_first = _is_first_message(session_id)
+
+        _save_message(session_id, "user", body.content)
+        _set_session_title(session_id, body.content)
+
+        if is_first:
+            set_first_session_at(datetime.utcnow())
+            request.app.state.is_first_run = False
+
+        history = _load_history(session_id)
+        session_row = _get_session(session_id)
+        mode = session_row.get("mode", "general")
+        system = build_system_prompt(mode)
+        registry = ToolRegistry()
+
+        try:
+            client = get_client()
+        except ConfigurationError as exc:
+            yield {"event": "error", "data": json.dumps({"message": str(exc)})}
+            return
+
+        reply_parts: list[str] = []
+        title = session_row.get("title") or body.content[:50]
+
+        try:
+            async for event in stream_response(
+                client, history, registry.get_tool_schemas(), system
+            ):
+                sse = _agent_event_to_sse(event, title, session_id)
+                if sse:
+                    yield sse
+                if isinstance(event, TextDeltaEvent):
+                    reply_parts.append(event.text)
+                elif isinstance(event, DoneEvent):
+                    break
+        except Exception as exc:
+            yield {"event": "error", "data": json.dumps({"message": str(exc)})}
+            return
+
+        if reply_parts:
+            _save_message(session_id, "assistant", "".join(reply_parts))
+
+    return EventSourceResponse(event_stream())
+
+
+def _agent_event_to_sse(event: AgentEvent, title: str, session_id: str) -> dict[str, Any] | None:
+    if isinstance(event, TextDeltaEvent):
+        return {"event": "text_delta", "data": json.dumps({"delta": event.text})}
+    if isinstance(event, ToolStartEvent):
+        return {
+            "event": "tool_start",
+            "data": json.dumps({"tool": event.tool, "description": event.tool_use_id}),
+        }
+    if isinstance(event, ToolEndEvent):
+        return {
+            "event": "tool_end",
+            "data": json.dumps({"tool": event.tool, "result_summary": event.result}),
+        }
+    if isinstance(event, ToolErrorEvent):
+        return {
+            "event": "tool_error",
+            "data": json.dumps({"tool": event.tool, "error": event.error}),
+        }
+    if isinstance(event, DoneEvent):
+        return {"event": "done", "data": json.dumps({"session_id": session_id, "title": title})}
+    return None
+
+
+@router.get("/sessions/{session_id}/messages")
+async def get_messages(session_id: str) -> list[dict[str, Any]]:
+    _get_session(session_id)
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT * FROM messages WHERE session_id = ? ORDER BY created_at ASC",
+        (session_id,),
+    ).fetchall()
+    return [dict(row) for row in rows]

--- a/src/weles/api/routers/preferences.py
+++ b/src/weles/api/routers/preferences.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException
+
+from weles.db.connection import get_db
+
+router = APIRouter(prefix="/preferences", tags=["preferences"])
+
+
+@router.delete("/{pref_id}", status_code=204)
+async def delete_preference(pref_id: str) -> None:
+    conn = get_db()
+    cur = conn.execute("DELETE FROM preferences WHERE id = ?", (pref_id,))
+    conn.commit()
+    if cur.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Preference not found")

--- a/src/weles/api/routers/profile.py
+++ b/src/weles/api/routers/profile.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from weles.db.profile_repo import _PROFILE_FIELDS, get_profile, update_profile
+
+router = APIRouter(prefix="/profile", tags=["profile"])
+
+
+@router.get("")
+async def get_profile_endpoint() -> dict[str, Any]:
+    return get_profile()
+
+
+@router.patch("")
+async def patch_profile(body: dict[str, Any]) -> dict[str, Any]:
+    unknown = set(body.keys()) - _PROFILE_FIELDS
+    if unknown:
+        raise HTTPException(status_code=422, detail=f"Unknown fields: {sorted(unknown)}")
+    return update_profile(body)

--- a/src/weles/api/routers/sessions.py
+++ b/src/weles/api/routers/sessions.py
@@ -1,0 +1,94 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from weles.db.connection import get_db
+
+router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+_VALID_MODES = {"general", "shopping", "diet", "fitness", "lifestyle"}
+
+
+class SessionPatch(BaseModel):
+    title: str | None = None
+    mode: str | None = None
+
+
+def _session_row(session_id: str) -> dict[str, Any] | None:
+    conn = get_db()
+    row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    return dict(row) if row else None
+
+
+def _session_preview(session_id: str) -> str | None:
+    conn = get_db()
+    row = conn.execute(
+        "SELECT content FROM messages WHERE session_id = ? AND role = 'user'"
+        " ORDER BY created_at ASC LIMIT 1",
+        (session_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return str(row["content"])[:60]
+
+
+@router.post("", status_code=201)
+async def create_session() -> dict[str, Any]:
+    conn = get_db()
+    session_id = str(uuid.uuid4())
+    now = datetime.utcnow()
+    conn.execute(
+        "INSERT INTO sessions (id, title, mode, created_at) VALUES (?, NULL, 'general', ?)",
+        (session_id, now),
+    )
+    conn.commit()
+    return {
+        "id": session_id,
+        "title": None,
+        "mode": "general",
+        "created_at": now.isoformat(),
+        "session_start_prompt": None,
+    }
+
+
+@router.get("")
+async def list_sessions() -> list[dict[str, Any]]:
+    conn = get_db()
+    rows = conn.execute("SELECT * FROM sessions ORDER BY created_at DESC").fetchall()
+    result = []
+    for row in rows:
+        d = dict(row)
+        d["preview"] = _session_preview(d["id"])
+        d["created_at"] = d["created_at"]
+        result.append(d)
+    return result
+
+
+@router.patch("/{session_id}")
+async def patch_session(session_id: str, body: SessionPatch) -> dict[str, Any]:
+    row = _session_row(session_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if body.mode is not None and body.mode not in _VALID_MODES:
+        raise HTTPException(status_code=422, detail=f"Invalid mode: {body.mode!r}")
+
+    conn = get_db()
+    if body.title is not None:
+        conn.execute("UPDATE sessions SET title = ? WHERE id = ?", (body.title, session_id))
+    if body.mode is not None:
+        conn.execute("UPDATE sessions SET mode = ? WHERE id = ?", (body.mode, session_id))
+    conn.commit()
+    return dict(conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone())
+
+
+@router.delete("/{session_id}", status_code=204)
+async def delete_session(session_id: str) -> None:
+    row = _session_row(session_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    conn = get_db()
+    conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+    conn.commit()

--- a/src/weles/api/routers/settings.py
+++ b/src/weles/api/routers/settings.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from weles.db.settings_repo import get_all_settings, known_keys, set_setting
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+@router.get("")
+async def get_settings() -> dict[str, Any]:
+    return get_all_settings()
+
+
+@router.patch("")
+async def patch_settings(body: dict[str, Any]) -> dict[str, Any]:
+    unknown = set(body.keys()) - known_keys()
+    if unknown:
+        raise HTTPException(status_code=422, detail=f"Unknown settings keys: {sorted(unknown)}")
+    for key, value in body.items():
+        set_setting(key, value)
+    return get_all_settings()

--- a/src/weles/api/startup.py
+++ b/src/weles/api/startup.py
@@ -28,25 +28,31 @@ _DEFAULT_SETTINGS = [
 
 
 def check_port_free() -> None:
-    """Exit with a readable message if WELES_PORT is already bound."""
+    """Exit with a readable message if WELES_PORT is already bound by another process."""
     port = int(os.getenv("WELES_PORT", "8000"))
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(0.1)
     try:
-        sock.bind(("127.0.0.1", port))
-    except OSError:
+        sock.connect(("127.0.0.1", port))
+        # Connection succeeded — something else is already listening on this port
+        sock.close()
         print(
             f"[ERROR] Port {port} is already in use."
             " Stop the existing Weles process and try again.",
             file=sys.stderr,
         )
         sys.exit(1)
+    except OSError:
+        # Connection refused or timed out — port is free
+        pass
     finally:
         sock.close()
 
 
 async def startup(state: Any) -> None:
     """Initialise app state: validate env, run migrations, seed settings."""
-    # 1. Load ~/.weles/.env if it exists — supplements env, does not override shell
+    # 1. Load repo-root .env then ~/.weles/.env — neither overrides shell env
+    load_dotenv(override=False)
     env_file = _WELES_DIR / ".env"
     if env_file.exists():
         load_dotenv(env_file, override=False)

--- a/src/weles/db/history_repo.py
+++ b/src/weles/db/history_repo.py
@@ -1,0 +1,51 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from weles.db.connection import get_db
+
+
+def get_history(domain: str | None = None, status: str | None = None) -> list[dict[str, Any]]:
+    conn = get_db()
+    query = "SELECT * FROM history"
+    params: list[Any] = []
+    filters = []
+    if domain:
+        filters.append("domain = ?")
+        params.append(domain)
+    if status:
+        filters.append("status = ?")
+        params.append(status)
+    if filters:
+        query += " WHERE " + " AND ".join(filters)
+    query += " ORDER BY created_at DESC"
+    rows = conn.execute(query, params).fetchall()
+    return [dict(row) for row in rows]
+
+
+def delete_history_item(item_id: str) -> bool:
+    conn = get_db()
+    cur = conn.execute("DELETE FROM history WHERE id = ?", (item_id,))
+    conn.commit()
+    return cur.rowcount > 0
+
+
+def add_to_history(
+    item_name: str,
+    category: str,
+    domain: str,
+    status: str,
+    rating: int | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    conn = get_db()
+    item_id = str(uuid.uuid4())
+    now = datetime.utcnow()
+    conn.execute(
+        "INSERT INTO history (id, item_name, category, domain, status, rating, notes, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (item_id, item_name, category, domain, status, rating, notes, now),
+    )
+    conn.commit()
+    row = conn.execute("SELECT * FROM history WHERE id = ?", (item_id,)).fetchone()
+    return dict(row)

--- a/src/weles/db/profile_repo.py
+++ b/src/weles/db/profile_repo.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from typing import Any
+
+from weles.db.connection import get_db
+
+_PROFILE_FIELDS = {
+    "height_cm",
+    "weight_kg",
+    "build",
+    "fitness_level",
+    "injury_history",
+    "dietary_restrictions",
+    "dietary_preferences",
+    "dietary_approach",
+    "aesthetic_style",
+    "brand_rejections",
+    "climate",
+    "activity_level",
+    "living_situation",
+    "country",
+    "budget_psychology",
+    "fitness_goal",
+    "dietary_goal",
+    "lifestyle_focus",
+}
+
+
+def get_profile() -> dict[str, Any]:
+    conn = get_db()
+    row = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
+    if row is None:
+        return {f: None for f in _PROFILE_FIELDS} | {
+            "id": 1,
+            "first_session_at": None,
+            "field_timestamps": "{}",
+        }
+    return dict(row)
+
+
+def update_profile(patch: dict[str, Any]) -> dict[str, Any]:
+    import json
+
+    conn = get_db()
+    existing = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
+
+    if existing is None:
+        conn.execute("INSERT INTO profile (id, field_timestamps) VALUES (1, '{}')")
+        conn.commit()
+        existing = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
+
+    timestamps = json.loads(existing["field_timestamps"] or "{}")
+    now_iso = datetime.utcnow().isoformat()
+
+    for field, value in patch.items():
+        conn.execute(f"UPDATE profile SET {field} = ? WHERE id = 1", (value,))  # noqa: S608
+        timestamps[field] = now_iso
+
+    conn.execute(
+        "UPDATE profile SET field_timestamps = ? WHERE id = 1",
+        (json.dumps(timestamps),),
+    )
+    conn.commit()
+    return dict(conn.execute("SELECT * FROM profile WHERE id = 1").fetchone())
+
+
+def set_first_session_at(dt: datetime) -> None:
+    conn = get_db()
+    existing = conn.execute("SELECT id FROM profile WHERE id = 1").fetchone()
+    if existing is None:
+        conn.execute(
+            "INSERT INTO profile (id, first_session_at, field_timestamps) VALUES (1, ?, '{}')",
+            (dt,),
+        )
+    else:
+        conn.execute(
+            "UPDATE profile SET first_session_at = ? WHERE id = 1 AND first_session_at IS NULL",
+            (dt,),
+        )
+    conn.commit()

--- a/src/weles/db/settings_repo.py
+++ b/src/weles/db/settings_repo.py
@@ -1,0 +1,39 @@
+import json
+from typing import Any
+
+from weles.db.connection import get_db
+
+_KNOWN_KEYS = {
+    "follow_up_cadence",
+    "proactive_surfacing",
+    "decay_thresholds",
+    "max_tool_calls_per_turn",
+}
+
+
+def get_all_settings() -> dict[str, Any]:
+    conn = get_db()
+    rows = conn.execute("SELECT key, value FROM settings").fetchall()
+    return {row["key"]: json.loads(row["value"]) for row in rows}
+
+
+def get_setting(key: str) -> Any:
+    conn = get_db()
+    row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    if row is None:
+        return None
+    return json.loads(row["value"])
+
+
+def set_setting(key: str, value: Any) -> None:
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES (?, ?)"
+        " ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, json.dumps(value)),
+    )
+    conn.commit()
+
+
+def known_keys() -> frozenset[str]:
+    return frozenset(_KNOWN_KEYS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from anthropic.types import RawContentBlockDeltaEvent, RawMessageStopEvent, TextDelta
@@ -26,6 +26,7 @@ def mock_claude(mocker: MockerFixture) -> MagicMock:
 
     mock_client.messages.stream.return_value = mock_stream
     mocker.patch("weles.agent.client.get_client", return_value=mock_client)
+    mocker.patch("weles.api.routers.messages.get_client", return_value=mock_client)
     return mock_client  # type: ignore[no-any-return]
 
 
@@ -34,6 +35,7 @@ def tmp_db(tmp_path: Path) -> Path:
     """Temporary SQLite DB with all Alembic migrations applied."""
     db_path = tmp_path / "weles.db"
     os.environ["WELES_DB_PATH"] = str(db_path)
+    os.environ.setdefault("ANTHROPIC_API_KEY", "test-key")
 
     from alembic import command
     from alembic.config import Config
@@ -53,5 +55,11 @@ def client(tmp_db: Path) -> object:
 
     from weles.api.main import app
 
-    with TestClient(app) as c:
+    # Bypass startup() side-effects (env validation, port check, re-migration).
+    # tmp_db already ran alembic; we set state flags manually.
+    async def _fake_startup(state: object) -> None:
+        state.web_search_available = False  # type: ignore[attr-defined]
+        state.is_first_run = True  # type: ignore[attr-defined]
+
+    with patch("weles.api.startup.startup", new=_fake_startup), TestClient(app) as c:
         yield c

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,50 @@
+def test_post_sessions_returns_201(client):
+    resp = client.post("/sessions")
+    assert resp.status_code == 201
+    body = resp.json()
+    assert "id" in body
+    assert body["title"] is None
+    assert body["mode"] == "general"
+    assert "created_at" in body
+    assert body["session_start_prompt"] is None
+
+
+def test_get_sessions_empty_on_fresh_db(client):
+    resp = client.get("/sessions")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_delete_session_returns_204_and_messages_404(client):
+    session_id = client.post("/sessions").json()["id"]
+    resp = client.delete(f"/sessions/{session_id}")
+    assert resp.status_code == 204
+    resp = client.get(f"/sessions/{session_id}/messages")
+    assert resp.status_code == 404
+
+
+def test_patch_session_mode(client):
+    session_id = client.post("/sessions").json()["id"]
+    resp = client.patch(f"/sessions/{session_id}", json={"mode": "shopping"})
+    assert resp.status_code == 200
+    assert resp.json()["mode"] == "shopping"
+
+
+def test_patch_settings_unknown_key_returns_422(client):
+    resp = client.patch("/settings", json={"nonexistent_key": "value"})
+    assert resp.status_code == 422
+
+
+def test_patch_settings_valid_key(client):
+    resp = client.patch("/settings", json={"follow_up_cadence": "weekly"})
+    assert resp.status_code == 200
+    assert resp.json()["follow_up_cadence"] == "weekly"
+
+
+def test_delete_data_returns_204_and_sessions_empty(client):
+    client.post("/sessions")
+    resp = client.delete("/data")
+    assert resp.status_code == 204
+    resp = client.get("/sessions")
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/tests/integration/test_sse.py
+++ b/tests/integration/test_sse.py
@@ -1,0 +1,41 @@
+import json
+
+
+def test_sse_content_type(client, mock_claude):
+    session_id = client.post("/sessions").json()["id"]
+    with client.stream(
+        "POST", f"/sessions/{session_id}/messages", json={"content": "Hello"}
+    ) as resp:
+        assert "text/event-stream" in resp.headers["content-type"]
+
+
+def test_sse_includes_text_delta_and_done(client, mock_claude):
+    session_id = client.post("/sessions").json()["id"]
+    events = []
+    with client.stream(
+        "POST", f"/sessions/{session_id}/messages", json={"content": "Hello"}
+    ) as resp:
+        for line in resp.iter_lines():
+            if line.startswith("event:"):
+                events.append(line.split(":", 1)[1].strip())
+
+    assert "text_delta" in events
+    assert "done" in events
+
+
+def test_sse_done_title_equals_first_50_chars(client, mock_claude):
+    session_id = client.post("/sessions").json()["id"]
+    content = "A" * 60
+    done_data = None
+    with client.stream(
+        "POST", f"/sessions/{session_id}/messages", json={"content": content}
+    ) as resp:
+        current_event = None
+        for line in resp.iter_lines():
+            if line.startswith("event:"):
+                current_event = line.split(":", 1)[1].strip()
+            elif line.startswith("data:") and current_event == "done":
+                done_data = json.loads(line.split(":", 1)[1].strip())
+
+    assert done_data is not None
+    assert done_data["title"] == content[:50]

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -6,8 +6,12 @@ from pytest_mock import MockerFixture
 from weles.utils.errors import ConfigurationError
 
 
-async def test_startup_raises_without_anthropic_key(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_startup_raises_without_anthropic_key(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    mocker.patch("weles.api.startup.load_dotenv")  # prevent .env from restoring the key
     from weles.api.startup import startup
 
     state = types.SimpleNamespace()
@@ -25,6 +29,7 @@ async def test_startup_web_search_false_without_tavily(
 
     mock_conn = mocker.MagicMock()
     mock_conn.execute.return_value.fetchone.side_effect = [(4,), None]
+    mocker.patch("weles.api.startup.load_dotenv")  # prevent .env from restoring keys
     mocker.patch("weles.api.startup.get_db", return_value=mock_conn)
     mocker.patch("weles.api.startup.check_port_free")
     mocker.patch("alembic.command.upgrade")


### PR DESCRIPTION
## Issue

Closes #5

## What this PR does

Full FastAPI REST API wired to SQLite, SSE streaming chat, and React UI replacing the CLI.

## Acceptance criteria

- [x] `POST /sessions` → 201 with `session_start_prompt: null`
- [x] `GET /sessions` → array with `preview`
- [x] `DELETE /sessions/{id}` → 204, cascades to messages
- [x] `PATCH /sessions/{id}` → updates title/mode
- [x] `POST /sessions/{id}/messages` → SSE stream with all event types
- [x] `GET /sessions/{id}/messages` → full message list
- [x] `GET /profile` / `PATCH /profile`
- [x] `GET /history?domain=&status=` / `DELETE /history/{id}`
- [x] `GET /settings` / `PATCH /settings` (rejects unknown keys with 422)
- [x] `DELETE /preferences/{id}`
- [x] `GET /health`
- [x] `DELETE /data` → alembic downgrade + upgrade; 204
- [x] `first_session_at` set on first-ever message; `is_first_run` flips to false
- [x] FastAPI lifespan wires `startup()` from #4
- [x] CORS `localhost:5173` in dev only
- [x] React UI: sidebar (240px), mode pills, streaming markdown, tool-use strip, settings page
- [x] `uv run weles` starts uvicorn; CLI REPL removed
- [x] `make build` produces `frontend/dist/` mounted as StaticFiles
- [x] Vite proxy routes all API paths to backend in dev

## Tests

- [x] All tests specified in the issue are present (`test_api.py`, `test_sse.py`)
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` — already complete from prior planning; no new endpoints beyond spec
- [ ] `docs/architecture.md` — no pattern changes; lifespan wiring was already documented

## Notes

- `conftest.py`: `client` fixture now patches `weles.api.startup.startup` with a no-op to avoid re-running alembic migrations (already applied by `tmp_db`). `mock_claude` also patches `weles.api.routers.messages.get_client` to handle the top-level import binding.
- `DELETE /data` runs real alembic in tests (not mocked); thread-local SQLite connection sees schema changes.