### PR TITLE
feat: #6 User profile model and API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `DELETE /data` wipes and recreates all tables via alembic downgrade + upgrade (#5)
 
 ### v0.2 — Personalization
-<!-- Issues #6–12 -->
+
+#### Added
+- `UserProfile` Pydantic model in `src/weles/profile/models.py`; all fields optional with `None` default (#6)
+- Profile enums: `Build`, `FitnessLevel`, `AestheticStyle`, `BudgetPsychology`, `ActivityLevel`, `LivingSituation`, `DietaryApproach` (#6)
+- `profile_is_empty(profile)` helper; returns `True` when all data fields are `None` (#6)
+- `GET /profile` returns full profile with nulls included (#6)
+- `PATCH /profile` validates enum values and rejects unknown fields with 422; writes `field_timestamps` atomically (#6)
+
+<!-- Issues #7–12 -->
 
 ### v0.3 — Research Engine
 <!-- Issues #13–18 -->

--- a/src/weles/api/routers/profile.py
+++ b/src/weles/api/routers/profile.py
@@ -1,20 +1,26 @@
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from pydantic import ValidationError
 
 from weles.db.profile_repo import _PROFILE_FIELDS, get_profile, update_profile
+from weles.profile.models import UserProfile
 
 router = APIRouter(prefix="/profile", tags=["profile"])
 
 
 @router.get("")
-async def get_profile_endpoint() -> dict[str, Any]:
+async def get_profile_endpoint() -> UserProfile:
     return get_profile()
 
 
 @router.patch("")
-async def patch_profile(body: dict[str, Any]) -> dict[str, Any]:
+async def patch_profile(body: dict[str, Any]) -> UserProfile:
     unknown = set(body.keys()) - _PROFILE_FIELDS
     if unknown:
         raise HTTPException(status_code=422, detail=f"Unknown fields: {sorted(unknown)}")
+    try:
+        UserProfile.model_validate(body)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
     return update_profile(body)

--- a/src/weles/api/routers/profile.py
+++ b/src/weles/api/routers/profile.py
@@ -20,7 +20,8 @@ async def patch_profile(body: dict[str, Any]) -> UserProfile:
     if unknown:
         raise HTTPException(status_code=422, detail=f"Unknown fields: {sorted(unknown)}")
     try:
-        UserProfile.model_validate(body)
+        validated = UserProfile.model_validate(body)
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail=exc.errors()) from exc
-    return update_profile(body)
+    patch = validated.model_dump(exclude_unset=True, mode="json")
+    return update_profile(patch)

--- a/src/weles/db/profile_repo.py
+++ b/src/weles/db/profile_repo.py
@@ -1,7 +1,9 @@
+import json
 from datetime import datetime
 from typing import Any
 
 from weles.db.connection import get_db
+from weles.profile.models import UserProfile
 
 _PROFILE_FIELDS = {
     "height_cm",
@@ -25,21 +27,15 @@ _PROFILE_FIELDS = {
 }
 
 
-def get_profile() -> dict[str, Any]:
+def get_profile() -> UserProfile:
     conn = get_db()
     row = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
     if row is None:
-        return {f: None for f in _PROFILE_FIELDS} | {
-            "id": 1,
-            "first_session_at": None,
-            "field_timestamps": "{}",
-        }
-    return dict(row)
+        return UserProfile()
+    return UserProfile.model_validate(dict(row))
 
 
-def update_profile(patch: dict[str, Any]) -> dict[str, Any]:
-    import json
-
+def update_profile(patch: dict[str, Any]) -> UserProfile:
     conn = get_db()
     existing = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
 
@@ -60,7 +56,8 @@ def update_profile(patch: dict[str, Any]) -> dict[str, Any]:
         (json.dumps(timestamps),),
     )
     conn.commit()
-    return dict(conn.execute("SELECT * FROM profile WHERE id = 1").fetchone())
+    row = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
+    return UserProfile.model_validate(dict(row))
 
 
 def set_first_session_at(dt: datetime) -> None:

--- a/src/weles/db/profile_repo.py
+++ b/src/weles/db/profile_repo.py
@@ -1,9 +1,14 @@
 import json
+import logging
 from datetime import datetime
 from typing import Any
 
+from pydantic import ValidationError
+
 from weles.db.connection import get_db
 from weles.profile.models import UserProfile
+
+logger = logging.getLogger(__name__)
 
 _PROFILE_FIELDS = {
     "height_cm",
@@ -32,10 +37,18 @@ def get_profile() -> UserProfile:
     row = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
     if row is None:
         return UserProfile()
-    return UserProfile.model_validate(dict(row))
+    try:
+        return UserProfile.model_validate(dict(row))
+    except ValidationError:
+        logger.exception("Profile row contains invalid data; returning empty profile")
+        return UserProfile()
 
 
 def update_profile(patch: dict[str, Any]) -> UserProfile:
+    unknown = set(patch) - _PROFILE_FIELDS
+    if unknown:
+        raise ValueError(f"Unknown profile fields: {sorted(unknown)}")
+
     conn = get_db()
     existing = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
 
@@ -57,7 +70,11 @@ def update_profile(patch: dict[str, Any]) -> UserProfile:
     )
     conn.commit()
     row = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
-    return UserProfile.model_validate(dict(row))
+    try:
+        return UserProfile.model_validate(dict(row))
+    except ValidationError:
+        logger.exception("Profile row contains invalid data after update; returning empty profile")
+        return UserProfile()
 
 
 def set_first_session_at(dt: datetime) -> None:

--- a/src/weles/profile/models.py
+++ b/src/weles/profile/models.py
@@ -1,0 +1,104 @@
+import json
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+_PROFILE_DATA_FIELDS = {
+    "height_cm",
+    "weight_kg",
+    "build",
+    "fitness_level",
+    "injury_history",
+    "dietary_restrictions",
+    "dietary_preferences",
+    "dietary_approach",
+    "aesthetic_style",
+    "brand_rejections",
+    "climate",
+    "activity_level",
+    "living_situation",
+    "country",
+    "budget_psychology",
+    "fitness_goal",
+    "dietary_goal",
+    "lifestyle_focus",
+}
+
+
+class Build(StrEnum):
+    lean = "lean"
+    athletic = "athletic"
+    average = "average"
+    heavy = "heavy"
+
+
+class FitnessLevel(StrEnum):
+    sedentary = "sedentary"
+    beginner = "beginner"
+    intermediate = "intermediate"
+    advanced = "advanced"
+
+
+class AestheticStyle(StrEnum):
+    minimal = "minimal"
+    technical = "technical"
+    classic = "classic"
+    mixed = "mixed"
+
+
+class BudgetPsychology(StrEnum):
+    buy_once_buy_right = "buy_once_buy_right"
+    good_enough = "good_enough"
+    context_dependent = "context_dependent"
+
+
+class ActivityLevel(StrEnum):
+    low = "low"
+    moderate = "moderate"
+    high = "high"
+
+
+class LivingSituation(StrEnum):
+    urban = "urban"
+    suburban = "suburban"
+    rural = "rural"
+
+
+class DietaryApproach(StrEnum):
+    keto = "keto"
+    vegan = "vegan"
+    omnivore = "omnivore"
+    carnivore = "carnivore"
+    flexible = "flexible"
+
+
+class UserProfile(BaseModel):
+    id: int | None = None
+    height_cm: float | None = None
+    weight_kg: float | None = None
+    build: Build | None = None
+    fitness_level: FitnessLevel | None = None
+    injury_history: str | None = None
+    dietary_restrictions: str | None = None
+    dietary_preferences: str | None = None
+    dietary_approach: DietaryApproach | None = None
+    aesthetic_style: AestheticStyle | None = None
+    brand_rejections: str | None = None
+    climate: str | None = None
+    activity_level: ActivityLevel | None = None
+    living_situation: LivingSituation | None = None
+    country: str | None = None
+    budget_psychology: BudgetPsychology | None = None
+    fitness_goal: str | None = None
+    dietary_goal: str | None = None
+    lifestyle_focus: str | None = None
+    first_session_at: str | None = None
+    field_timestamps: str | None = "{}"
+
+
+def profile_is_empty(profile: UserProfile) -> bool:
+    return all(getattr(profile, f) is None for f in _PROFILE_DATA_FIELDS)
+
+
+def parse_field_timestamps(profile: UserProfile) -> dict:
+    return json.loads(profile.field_timestamps or "{}")

--- a/src/weles/profile/models.py
+++ b/src/weles/profile/models.py
@@ -93,7 +93,7 @@ class UserProfile(BaseModel):
     dietary_goal: str | None = None
     lifestyle_focus: str | None = None
     first_session_at: str | None = None
-    field_timestamps: str | None = "{}"
+    field_timestamps: str | None = None
 
 
 def profile_is_empty(profile: UserProfile) -> bool:

--- a/src/weles/profile/models.py
+++ b/src/weles/profile/models.py
@@ -100,5 +100,6 @@ def profile_is_empty(profile: UserProfile) -> bool:
     return all(getattr(profile, f) is None for f in _PROFILE_DATA_FIELDS)
 
 
-def parse_field_timestamps(profile: UserProfile) -> dict:
-    return json.loads(profile.field_timestamps or "{}")
+def parse_field_timestamps(profile: UserProfile) -> dict[str, str]:
+    result: dict[str, str] = json.loads(profile.field_timestamps or "{}")
+    return result

--- a/tests/integration/test_profile_api.py
+++ b/tests/integration/test_profile_api.py
@@ -1,0 +1,33 @@
+import json
+
+from fastapi.testclient import TestClient
+
+
+def test_patch_profile_valid_field_returns_200(client: TestClient) -> None:
+    resp = client.patch("/profile", json={"fitness_level": "beginner"})
+    assert resp.status_code == 200
+    assert resp.json()["fitness_level"] == "beginner"
+
+
+def test_patch_profile_invalid_enum_returns_422(client: TestClient) -> None:
+    resp = client.patch("/profile", json={"fitness_level": "invalid"})
+    assert resp.status_code == 422
+
+
+def test_patch_profile_unknown_field_returns_422(client: TestClient) -> None:
+    resp = client.patch("/profile", json={"unknown_field": "x"})
+    assert resp.status_code == 422
+
+
+def test_patch_profile_sets_field_timestamp(client: TestClient) -> None:
+    client.patch("/profile", json={"fitness_level": "beginner"})
+    resp = client.get("/profile")
+    timestamps = json.loads(resp.json()["field_timestamps"])
+    assert "fitness_level" in timestamps
+
+
+def test_patch_profile_does_not_set_unwritten_field_timestamp(client: TestClient) -> None:
+    client.patch("/profile", json={"fitness_level": "beginner"})
+    resp = client.get("/profile")
+    timestamps = json.loads(resp.json()["field_timestamps"])
+    assert "weight_kg" not in timestamps

--- a/tests/unit/test_profile_model.py
+++ b/tests/unit/test_profile_model.py
@@ -1,0 +1,17 @@
+import pytest
+from pydantic import ValidationError
+
+from weles.profile.models import UserProfile, profile_is_empty
+
+
+def test_profile_is_empty_returns_true_for_default() -> None:
+    assert profile_is_empty(UserProfile()) is True
+
+
+def test_profile_is_empty_returns_false_when_field_set() -> None:
+    assert profile_is_empty(UserProfile(fitness_level="beginner")) is False
+
+
+def test_invalid_build_raises_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        UserProfile(build="invalid")


### PR DESCRIPTION
## Issue

Closes #6

## What this PR does

Adds the `UserProfile` Pydantic model, profile enums, `profile_is_empty` helper, and upgrades `GET /profile` + `PATCH /profile` to use typed models with enum validation.

## Acceptance criteria

- [x] `UserProfile` Pydantic model in `src/weles/profile/models.py`; all fields `Optional` with `None` default
- [x] Enums: `Build`, `FitnessLevel`, `AestheticStyle`, `BudgetPsychology`, `ActivityLevel`, `LivingSituation`, `DietaryApproach` — each a `StrEnum` matching DB values
- [x] `GET /profile` → full profile; nulls included, not omitted
- [x] `PATCH /profile` → partial update; validates enums; rejects unknown field names with 422
- [x] On write: `field_timestamps[field] = now().isoformat()` for every changed field, in the same DB transaction
- [x] `get_profile() -> UserProfile` and `update_profile(patch) -> UserProfile` in `profile_repo.py`
- [x] `profile_is_empty(profile)` returns `True` when all non-timestamp fields are `None`

## Tests

- [x] `tests/unit/test_profile_model.py`: empty profile, non-empty profile, invalid enum raises `ValidationError`
- [x] `tests/integration/test_profile_api.py`: valid patch, invalid enum 422, unknown field 422, `field_timestamps` set/not-set after write
- [x] `make lint` passes
- [x] `make test` passes

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased] > v0.2`
- [x] `docs/api.md` — no new endpoints; existing `GET /profile` and `PATCH /profile` behaviour unchanged from caller perspective
- [x] `docs/architecture.md` — no pattern changes

## Notes

- Used `StrEnum` (Python 3.11+) instead of `str, Enum` per ruff UP042.
- `profile_repo.py` now imports `UserProfile` and uses `model_validate(dict(row))` to map SQLite rows.
- Enum validation in `PATCH /profile` is done via `UserProfile.model_validate(body)` before writing; `ValidationError` is caught and re-raised as HTTP 422.