### PR TITLE
feat: #10 Settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `build_profile_block(profile, preferences)` in `profile/context.py`; serialises non-null fields into a compact `[User Profile]` block; returns `None` when empty (#8)
 - Profile + preferences injected as Block 3 of every Claude request; block regenerated fresh on each message (#8)
 - Token warning logged when profile block exceeds 500 tokens (#8)
+- Settings page with human-readable decay threshold labels, Save button, and permanent-delete confirmation modal (#10)
 
-<!-- Issues #9–12 -->
+<!-- Issues #9, #11–12 -->
 
 ### v0.3 — Research Engine
 <!-- Issues #13–18 -->

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,15 +24,26 @@ const DECAY_LABELS: Record<string, string> = {
   taste_lifestyle: 'Taste & lifestyle (days)',
 }
 
+const DECAY_DEFAULTS: Record<string, number> = {
+  goals: 60,
+  fitness_level: 90,
+  dietary_approach: 90,
+  body_metrics: 180,
+  taste_lifestyle: 365,
+}
+
 function SettingsPage({ onBack }: { onBack: () => void }) {
   const [settings, setSettings] = useState<Record<string, unknown>>({})
   const [confirmClear, setConfirmClear] = useState(false)
-  const [decayDraft, setDecayDraft] = useState<Record<string, number>>({})
+  const [decayDraft, setDecayDraft] = useState<Record<string, number>>(DECAY_DEFAULTS)
+  const [settingsLoaded, setSettingsLoaded] = useState(false)
 
   useEffect(() => {
     getSettings().then(s => {
       setSettings(s)
-      setDecayDraft((s.decay_thresholds as Record<string, number>) ?? {})
+      const fromServer = (s.decay_thresholds as Record<string, number>) ?? {}
+      setDecayDraft({ ...DECAY_DEFAULTS, ...fromServer })
+      setSettingsLoaded(true)
     })
   }, [])
 
@@ -44,7 +55,8 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
   async function saveDecay() {
     const updated = await patchSettings({ decay_thresholds: decayDraft })
     setSettings(updated)
-    setDecayDraft((updated.decay_thresholds as Record<string, number>) ?? {})
+    const fromServer = (updated.decay_thresholds as Record<string, number>) ?? {}
+    setDecayDraft({ ...DECAY_DEFAULTS, ...fromServer })
   }
 
   async function handleClearData() {
@@ -86,17 +98,17 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
 
       <section>
         <h2>Profile decay thresholds</h2>
-        {Object.entries(decayDraft).map(([key, val]) => (
+        {Object.keys(DECAY_LABELS).map(key => (
           <label key={key}>
-            {DECAY_LABELS[key] ?? key}
+            {DECAY_LABELS[key]}
             <input
               type="number"
-              value={val}
+              value={decayDraft[key] ?? DECAY_DEFAULTS[key]}
               onChange={e => setDecayDraft(prev => ({ ...prev, [key]: Number(e.target.value) }))}
             />
           </label>
         ))}
-        <button onClick={saveDecay}>Save</button>
+        <button onClick={saveDecay} disabled={!settingsLoaded}>Save</button>
       </section>
 
       <section>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,13 +16,24 @@ const MODE_LABELS: Record<Mode, string> = {
 
 // ── Settings page ────────────────────────────────────────────────────────────
 
+const DECAY_LABELS: Record<string, string> = {
+  goals: 'Goals (days)',
+  fitness_level: 'Fitness level (days)',
+  dietary_approach: 'Dietary approach (days)',
+  body_metrics: 'Body metrics (days)',
+  taste_lifestyle: 'Taste & lifestyle (days)',
+}
+
 function SettingsPage({ onBack }: { onBack: () => void }) {
   const [settings, setSettings] = useState<Record<string, unknown>>({})
   const [confirmClear, setConfirmClear] = useState(false)
-  const [cleared, setCleared] = useState(false)
+  const [decayDraft, setDecayDraft] = useState<Record<string, number>>({})
 
   useEffect(() => {
-    getSettings().then(setSettings)
+    getSettings().then(s => {
+      setSettings(s)
+      setDecayDraft((s.decay_thresholds as Record<string, number>) ?? {})
+    })
   }, [])
 
   async function save(patch: Record<string, unknown>) {
@@ -30,13 +41,16 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
     setSettings(updated)
   }
 
-  async function handleClearData() {
-    await clearData()
-    setConfirmClear(false)
-    setCleared(true)
+  async function saveDecay() {
+    const updated = await patchSettings({ decay_thresholds: decayDraft })
+    setSettings(updated)
+    setDecayDraft((updated.decay_thresholds as Record<string, number>) ?? {})
   }
 
-  const decayThresholds = (settings.decay_thresholds as Record<string, number>) ?? {}
+  async function handleClearData() {
+    await clearData()
+    onBack()
+  }
 
   return (
     <div className="settings-page">
@@ -71,27 +85,25 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
       </section>
 
       <section>
-        <h2>Profile decay thresholds (days)</h2>
-        {Object.entries(decayThresholds).map(([key, val]) => (
+        <h2>Profile decay thresholds</h2>
+        {Object.entries(decayDraft).map(([key, val]) => (
           <label key={key}>
-            {key}
+            {DECAY_LABELS[key] ?? key}
             <input
               type="number"
               value={val}
-              onChange={e =>
-                save({ decay_thresholds: { ...decayThresholds, [key]: Number(e.target.value) } })
-              }
+              onChange={e => setDecayDraft(prev => ({ ...prev, [key]: Number(e.target.value) }))}
             />
           </label>
         ))}
+        <button onClick={saveDecay}>Save</button>
       </section>
 
       <section>
         <h2>Data</h2>
-        {cleared && <p className="cleared-notice">All data cleared.</p>}
         {confirmClear ? (
           <div className="confirm-modal">
-            <p>This will delete all sessions, history, profile, and preferences. Cannot be undone.</p>
+            <p>This will permanently delete all sessions, history, profile, and preferences. Cannot be undone.</p>
             <button onClick={handleClearData}>Confirm</button>
             <button onClick={() => setConfirmClear(false)}>Cancel</button>
           </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -38,5 +38,6 @@ export async function patchSettings(patch: Record<string, unknown>): Promise<Rec
 }
 
 export async function clearData(): Promise<void> {
-  await fetch('/data', { method: 'DELETE' })
+  const r = await fetch('/data', { method: 'DELETE' })
+  if (!r.ok) throw new Error(`DELETE /data failed: ${r.status}`)
 }


### PR DESCRIPTION
## Issue

Closes #10

## What this PR does

Fixes four gaps in the existing SettingsPage component to match the acceptance criteria.

## Acceptance criteria

- [x] Route `/settings` in frontend; sidebar link "Settings"
- [x] Follow-up cadence selector: Off / Weekly / Monthly; PATCH on change
- [x] Proactive surfacing toggle; PATCH on change
- [x] Five decay threshold inputs with human-readable labels (Goals, Fitness level, Dietary approach, Body metrics, Taste & lifestyle)
- [x] Save button for decay thresholds (no auto-save on keystroke)
- [x] "Clear all data" button with confirmation modal
- [x] Modal text: "This will permanently delete all sessions, history, profile, and preferences. Cannot be undone."
- [x] On confirm: DELETE /data; redirect to chat view

## Tests

- [x] All tests specified in the issue are present (frontend only — manual)
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (no endpoint changes)
- [ ] `docs/architecture.md` updated (no pattern changes)