### PR TITLE
feat: #11 Proactive information gathering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Profile + preferences injected as Block 3 of every Claude request; block regenerated fresh on each message (#8)
 - Token warning logged when profile block exceeds 500 tokens (#8)
 - Settings page with human-readable decay threshold labels, Save button, and permanent-delete confirmation modal (#10)
+- `check_missing_fields(mode, profile)` in `agent/context.py`; returns null profile fields relevant to current mode (#11)
+- `save_profile_field` Claude tool in `tools/profile_tools.py`; registered in `ToolRegistry` on every request (#11)
+- Missing profile fields injected as `[System: ...]` note into user turn before each Claude request; each field asked at most once per session (#11)
 
-<!-- Issues #9, #11–12 -->
+<!-- Issues #9, #12 -->
 
 ### v0.3 — Research Engine
 <!-- Issues #13–18 -->

--- a/src/weles/agent/context.py
+++ b/src/weles/agent/context.py
@@ -1,0 +1,15 @@
+from weles.profile.models import UserProfile
+
+_FIELDS_BY_MODE: dict[str, list[str]] = {
+    "shopping": ["budget_psychology", "aesthetic_style", "country"],
+    "diet": ["dietary_restrictions", "dietary_approach"],
+    "fitness": ["fitness_level", "injury_history"],
+    "lifestyle": ["living_situation", "climate"],
+    "general": [],
+}
+
+
+def check_missing_fields(mode: str, profile: UserProfile) -> list[str]:
+    """Return profile fields relevant to *mode* that are currently null."""
+    relevant = _FIELDS_BY_MODE.get(mode, [])
+    return [f for f in relevant if getattr(profile, f) is None]

--- a/src/weles/agent/session.py
+++ b/src/weles/agent/session.py
@@ -4,6 +4,7 @@ from typing import Any
 class Session:
     def __init__(self) -> None:
         self.messages: list[dict[str, Any]] = []
+        self.asked_this_session: set[str] = set()
 
     def add_message(self, role: str, content: str | list[Any]) -> None:
         self.messages.append({"role": role, "content": content})

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -9,8 +9,10 @@ from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
 from weles.agent.client import get_client
+from weles.agent.context import check_missing_fields
 from weles.agent.dispatch import ToolRegistry
 from weles.agent.prompts import build_system_prompt
+from weles.agent.session import Session
 from weles.agent.stream import (
     AgentEvent,
     DoneEvent,
@@ -22,9 +24,19 @@ from weles.agent.stream import (
 )
 from weles.db.connection import get_db
 from weles.db.profile_repo import get_preferences, get_profile, set_first_session_at
+from weles.tools.profile_tools import SAVE_PROFILE_FIELD_SCHEMA, save_profile_field_handler
 from weles.utils.errors import ConfigurationError
 
 router = APIRouter(tags=["messages"])
+
+# In-memory per-session state (survives requests, reset on server restart)
+_sessions: dict[str, Session] = {}
+
+
+def _get_or_create_session(session_id: str) -> Session:
+    if session_id not in _sessions:
+        _sessions[session_id] = Session()
+    return _sessions[session_id]
 
 
 class MessageBody(BaseModel):
@@ -93,12 +105,32 @@ async def post_message(session_id: str, body: MessageBody, request: Request) -> 
         history = _load_history(session_id)
         session_row = _get_session(session_id)
         mode = session_row.get("mode", "general")
+        profile = get_profile()
         try:
-            system = build_system_prompt(mode, get_profile(), get_preferences())
+            system = build_system_prompt(mode, profile, get_preferences())
         except ValueError as exc:
             yield {"event": "error", "data": json.dumps({"message": str(exc)})}
             return
+
+        # Inject missing-field note into the user turn
+        mem_session = _get_or_create_session(session_id)
+        missing = check_missing_fields(mode, profile)
+        unasked = [f for f in missing if f not in mem_session.asked_this_session]
+        if unasked:
+            note = (
+                f"[System: Profile fields unset and relevant: {unasked}. "
+                "Infer from user message if possible and call save_profile_field. "
+                "Otherwise ask for at most one.]"
+            )
+            history[-1]["content"] = history[-1]["content"] + "\n\n" + note
+            mem_session.asked_this_session.update(unasked)
+
         registry = ToolRegistry()
+        registry.register(
+            "save_profile_field",
+            save_profile_field_handler,
+            SAVE_PROFILE_FIELD_SCHEMA,
+        )
 
         try:
             client = get_client()

--- a/src/weles/tools/profile_tools.py
+++ b/src/weles/tools/profile_tools.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+from weles.db.profile_repo import update_profile
+
+_VALID_FIELDS = {
+    "height_cm",
+    "weight_kg",
+    "build",
+    "fitness_level",
+    "injury_history",
+    "dietary_restrictions",
+    "dietary_preferences",
+    "dietary_approach",
+    "aesthetic_style",
+    "brand_rejections",
+    "climate",
+    "activity_level",
+    "living_situation",
+    "country",
+    "budget_psychology",
+    "fitness_goal",
+    "dietary_goal",
+    "lifestyle_focus",
+}
+
+SAVE_PROFILE_FIELD_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "field": {
+            "type": "string",
+            "description": "Profile field name to update.",
+        },
+        "value": {
+            "type": "string",
+            "description": "New value for the field.",
+        },
+    },
+    "required": ["field", "value"],
+}
+
+
+def save_profile_field(field: str, value: str) -> str:
+    """Save a single profile field. Raises ValueError for unknown fields."""
+    if field not in _VALID_FIELDS:
+        raise ValueError(f"Unknown profile field: {field!r}")
+    update_profile({field: value})
+    return f"Saved {field} = {value!r}"
+
+
+def save_profile_field_handler(tool_input: dict[str, Any]) -> str:
+    return save_profile_field(tool_input["field"], tool_input["value"])

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,0 +1,22 @@
+from weles.agent.context import check_missing_fields
+from weles.profile.models import UserProfile
+
+
+def test_shopping_empty_profile_returns_all_fields() -> None:
+    result = check_missing_fields("shopping", UserProfile())
+    assert result == ["budget_psychology", "aesthetic_style", "country"]
+
+
+def test_shopping_one_field_set_excludes_it() -> None:
+    result = check_missing_fields("shopping", UserProfile(budget_psychology="good_enough"))
+    assert result == ["aesthetic_style", "country"]
+
+
+def test_general_always_returns_empty() -> None:
+    result = check_missing_fields("general", UserProfile())
+    assert result == []
+
+
+def test_diet_one_field_set_returns_other() -> None:
+    result = check_missing_fields("diet", UserProfile(dietary_restrictions="gluten"))
+    assert result == ["dietary_approach"]

--- a/tests/unit/test_save_profile_field.py
+++ b/tests/unit/test_save_profile_field.py
@@ -1,0 +1,14 @@
+import pytest
+
+from weles.tools.profile_tools import save_profile_field
+
+
+def test_save_profile_field_calls_update_profile(mocker) -> None:  # type: ignore[no-untyped-def]
+    mock_update = mocker.patch("weles.tools.profile_tools.update_profile")
+    save_profile_field("fitness_level", "beginner")
+    mock_update.assert_called_once_with({"fitness_level": "beginner"})
+
+
+def test_save_profile_field_unknown_field_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown profile field"):
+        save_profile_field("unknown_field", "x")


### PR DESCRIPTION
## Issue

Closes #11

## What this PR does

When the user sends a message in a mode with null required profile fields, a `[System: ...]` note is appended to the user turn instructing Claude to ask for at most one missing field. Each field is asked at most once per server session.

## Acceptance criteria

- [x] `check_missing_fields(mode, profile) -> list[str]` in `agent/context.py`
- [x] Mode → field mapping: shopping, diet, fitness, lifestyle, general
- [x] Returns only null fields
- [x] `[System: ...]` note appended to user turn when unasked missing fields exist
- [x] `asked_this_session: set[str]` on `Session`; fields marked after injection
- [x] `save_profile_field(field, value)` tool in `tools/profile_tools.py`; raises `ValueError` for unknown fields
- [x] Tool registered in `ToolRegistry` on every request

## Tests

- [x] `tests/unit/test_context.py`: 4 cases covering shopping (empty + partial), general, diet
- [x] `tests/unit/test_save_profile_field.py`: calls `update_profile` correctly; raises on unknown field
- [x] `make lint` passes
- [x] `make test` passes (52 passed)
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (no endpoint changes)
- [ ] `docs/architecture.md` updated (no new patterns; `agent/context.py` already listed in module map)

## Notes

- The issue test spec uses `dietary_restrictions=["gluten"]` but the model field is `str | None`; test written with `"gluten"` string value instead.
- `_sessions` dict is module-level in `messages.py`; resets on server restart (by design — "session lifetime only").