### PR TITLE
feat: #13 Tool-use progress via structured SSE events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 <!-- Issues #9, #12 -->
 
 ### v0.3 — Research Engine
-<!-- Issues #13–18 -->
+
+#### Added
+- `ToolResult(summary, data)` named tuple returned by `ToolRegistry.dispatch()`; `summary` drives `tool_end` SSE, `data` is sent to Claude (#13)
+- Agentic tool-use loop in `stream_response`: streams text deltas, then processes `tool_use` blocks, emits `ToolStartEvent`/`ToolEndEvent`/`ToolErrorEvent`, and continues until `end_turn` (#13)
+- Human-readable `ToolStartEvent.description` per tool: `search_reddit`, `search_web`, `add_to_history`, `save_profile_field`, and a generic fallback (#13)
+- Tool exceptions caught in the loop and emitted as `ToolErrorEvent`; Claude instructed to continue with available data (#13)
+
+<!-- Issues #14–18 -->
 
 ### v0.4 — Domain Modules
 <!-- Issues #19–22 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Profile + preferences injected as Block 3 of every Claude request; block regenerated fresh on each message (#8)
 - Token warning logged when profile block exceeds 500 tokens (#8)
 - Settings page with human-readable decay threshold labels, Save button, and permanent-delete confirmation modal (#10)
+- `check_missing_fields(mode, profile)` in `agent/context.py`; returns null profile fields relevant to current mode (#11)
+- `save_profile_field` Claude tool in `tools/profile_tools.py`; registered in `ToolRegistry` on every request (#11)
+- Missing profile fields injected as `[System: ...]` note into user turn before each Claude request; each field asked at most once per session (#11)
 
-<!-- Issues #9, #11–12 -->
+<!-- Issues #9, #12 -->
 
 ### v0.3 — Research Engine
 <!-- Issues #13–18 -->

--- a/src/weles/agent/context.py
+++ b/src/weles/agent/context.py
@@ -1,0 +1,15 @@
+from weles.profile.models import UserProfile
+
+_FIELDS_BY_MODE: dict[str, list[str]] = {
+    "shopping": ["budget_psychology", "aesthetic_style", "country"],
+    "diet": ["dietary_restrictions", "dietary_approach"],
+    "fitness": ["fitness_level", "injury_history"],
+    "lifestyle": ["living_situation", "climate"],
+    "general": [],
+}
+
+
+def check_missing_fields(mode: str, profile: UserProfile) -> list[str]:
+    """Return profile fields relevant to *mode* that are currently null."""
+    relevant = _FIELDS_BY_MODE.get(mode, [])
+    return [f for f in relevant if getattr(profile, f) is None]

--- a/src/weles/agent/dispatch.py
+++ b/src/weles/agent/dispatch.py
@@ -1,7 +1,12 @@
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NamedTuple
 
 from weles.utils.errors import ToolNotFoundError
+
+
+class ToolResult(NamedTuple):
+    summary: str
+    data: Any
 
 
 class ToolRegistry:
@@ -13,11 +18,14 @@ class ToolRegistry:
         self._handlers[name] = handler
         self._schemas[name] = schema
 
-    def dispatch(self, tool_name: str, tool_input: dict[str, Any]) -> str:
+    def dispatch(self, tool_name: str, tool_input: dict[str, Any]) -> ToolResult:
         if tool_name not in self._handlers:
             raise ToolNotFoundError(f"Unknown tool: {tool_name!r}")
         result = self._handlers[tool_name](tool_input)
-        return str(result)
+        if isinstance(result, ToolResult):
+            return result
+        s = str(result)
+        return ToolResult(summary=s, data=s)
 
     def get_tool_schemas(self) -> list[dict[str, Any]]:
         return [{"name": name, "input_schema": schema} for name, schema in self._schemas.items()]

--- a/src/weles/agent/session.py
+++ b/src/weles/agent/session.py
@@ -4,6 +4,7 @@ from typing import Any
 class Session:
     def __init__(self) -> None:
         self.messages: list[dict[str, Any]] = []
+        self.asked_this_session: set[str] = set()
 
     def add_message(self, role: str, content: str | list[Any]) -> None:
         self.messages.append({"role": role, "content": content})

--- a/src/weles/agent/stream.py
+++ b/src/weles/agent/stream.py
@@ -1,10 +1,18 @@
 import os
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import anthropic
-from anthropic.types import RawContentBlockDeltaEvent, RawMessageStopEvent, TextDelta
+from anthropic.types import (
+    RawContentBlockDeltaEvent,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+)
+
+if TYPE_CHECKING:
+    from weles.agent.dispatch import ToolRegistry
 
 
 @dataclass
@@ -15,13 +23,13 @@ class TextDeltaEvent:
 @dataclass
 class ToolStartEvent:
     tool: str
-    tool_use_id: str
+    description: str
 
 
 @dataclass
 class ToolEndEvent:
     tool: str
-    result: str
+    result_summary: str
 
 
 @dataclass
@@ -38,28 +46,102 @@ class DoneEvent:
 AgentEvent = TextDeltaEvent | ToolStartEvent | ToolEndEvent | ToolErrorEvent | DoneEvent
 
 
+def _build_description(tool_name: str, tool_input: dict[str, Any]) -> str:
+    if tool_name == "search_reddit":
+        query = tool_input.get("query", "")
+        subreddits = tool_input.get("subreddits", [])
+        if subreddits:
+            subs = ", ".join(f"r/{s}" for s in subreddits)
+            return f"Searching {subs} for '{query}'…"
+        return f"Searching Reddit for '{query}'…"
+    if tool_name == "search_web":
+        query = tool_input.get("query", "")
+        return f"Searching web for '{query}'…"
+    if tool_name == "add_to_history":
+        item_name = tool_input.get("item_name", "item")
+        return f"Saving {item_name} to history…"
+    if tool_name == "save_profile_field":
+        field = tool_input.get("field", "field")
+        return f"Saving {field} to your profile…"
+    return f"Running {tool_name}…"
+
+
 async def stream_response(
     client: anthropic.Anthropic,
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]],
     system: list[dict[str, Any]],
+    registry: "ToolRegistry | None" = None,
 ) -> AsyncIterator[AgentEvent]:
     model = os.environ.get("WELES_MODEL", "claude-sonnet-4-6")
     max_tokens = int(os.environ.get("WELES_MAX_TOKENS", "4096"))
 
-    kwargs: dict[str, Any] = {
-        "model": model,
-        "max_tokens": max_tokens,
-        "messages": messages,
-    }
-    if system:
-        kwargs["system"] = system
-    if tools:
-        kwargs["tools"] = tools
+    current_messages = list(messages)
 
-    with client.messages.stream(**kwargs) as stream:
-        for event in stream:
-            if isinstance(event, RawContentBlockDeltaEvent) and isinstance(event.delta, TextDelta):
-                yield TextDeltaEvent(text=event.delta.text)
-            elif isinstance(event, RawMessageStopEvent):
-                yield DoneEvent()
+    while True:
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": current_messages,
+        }
+        if system:
+            kwargs["system"] = system
+        if tools:
+            kwargs["tools"] = tools
+
+        with client.messages.stream(**kwargs) as stream:
+            for event in stream:
+                if isinstance(event, RawContentBlockDeltaEvent) and isinstance(
+                    event.delta, TextDelta
+                ):
+                    yield TextDeltaEvent(text=event.delta.text)
+            final_message = stream.get_final_message()
+
+        if final_message.stop_reason != "tool_use" or registry is None:
+            yield DoneEvent()
+            break
+
+        tool_uses = [b for b in final_message.content if isinstance(b, ToolUseBlock)]
+        tool_results = []
+
+        for tool_use in tool_uses:
+            description = _build_description(tool_use.name, tool_use.input)
+            yield ToolStartEvent(tool=tool_use.name, description=description)
+            try:
+                result = registry.dispatch(tool_use.name, tool_use.input)
+                yield ToolEndEvent(tool=tool_use.name, result_summary=result.summary)
+                result_content = str(result.data)
+            except Exception as exc:
+                error_msg = str(exc)
+                yield ToolErrorEvent(tool=tool_use.name, error=error_msg)
+                result_content = (
+                    f"Tool {tool_use.name} failed: {error_msg}. "
+                    "Continue with available data; note the limitation in your response."
+                )
+
+            tool_results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use.id,
+                    "content": result_content,
+                }
+            )
+
+        assistant_content: list[dict[str, Any]] = []
+        for block in final_message.content:
+            if isinstance(block, TextBlock):
+                assistant_content.append({"type": "text", "text": block.text})
+            elif isinstance(block, ToolUseBlock):
+                assistant_content.append(
+                    {
+                        "type": "tool_use",
+                        "id": block.id,
+                        "name": block.name,
+                        "input": block.input,
+                    }
+                )
+
+        current_messages = current_messages + [
+            {"role": "assistant", "content": assistant_content},
+            {"role": "user", "content": tool_results},
+        ]

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -143,7 +143,7 @@ async def post_message(session_id: str, body: MessageBody, request: Request) -> 
 
         try:
             async for event in stream_response(
-                client, history, registry.get_tool_schemas(), system
+                client, history, registry.get_tool_schemas(), system, registry
             ):
                 sse = _agent_event_to_sse(event, title, session_id)
                 if sse:
@@ -168,12 +168,12 @@ def _agent_event_to_sse(event: AgentEvent, title: str, session_id: str) -> dict[
     if isinstance(event, ToolStartEvent):
         return {
             "event": "tool_start",
-            "data": json.dumps({"tool": event.tool, "description": event.tool_use_id}),
+            "data": json.dumps({"tool": event.tool, "description": event.description}),
         }
     if isinstance(event, ToolEndEvent):
         return {
             "event": "tool_end",
-            "data": json.dumps({"tool": event.tool, "result_summary": event.result}),
+            "data": json.dumps({"tool": event.tool, "result_summary": event.result_summary}),
         }
     if isinstance(event, ToolErrorEvent):
         return {

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -9,8 +9,10 @@ from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
 from weles.agent.client import get_client
+from weles.agent.context import check_missing_fields
 from weles.agent.dispatch import ToolRegistry
 from weles.agent.prompts import build_system_prompt
+from weles.agent.session import Session
 from weles.agent.stream import (
     AgentEvent,
     DoneEvent,
@@ -22,9 +24,19 @@ from weles.agent.stream import (
 )
 from weles.db.connection import get_db
 from weles.db.profile_repo import get_preferences, get_profile, set_first_session_at
+from weles.tools.profile_tools import SAVE_PROFILE_FIELD_SCHEMA, save_profile_field_handler
 from weles.utils.errors import ConfigurationError
 
 router = APIRouter(tags=["messages"])
+
+# In-memory per-session state (survives requests, reset on server restart)
+_sessions: dict[str, Session] = {}
+
+
+def _get_or_create_session(session_id: str) -> Session:
+    if session_id not in _sessions:
+        _sessions[session_id] = Session()
+    return _sessions[session_id]
 
 
 class MessageBody(BaseModel):
@@ -93,12 +105,32 @@ async def post_message(session_id: str, body: MessageBody, request: Request) -> 
         history = _load_history(session_id)
         session_row = _get_session(session_id)
         mode = session_row.get("mode", "general")
+        profile = get_profile()
         try:
-            system = build_system_prompt(mode, get_profile(), get_preferences())
+            system = build_system_prompt(mode, profile, get_preferences())
         except ValueError as exc:
             yield {"event": "error", "data": json.dumps({"message": str(exc)})}
             return
+
+        # Inject missing-field note into the user turn
+        mem_session = _get_or_create_session(session_id)
+        missing = check_missing_fields(mode, profile)
+        unasked = [f for f in missing if f not in mem_session.asked_this_session]
+        if unasked:
+            note = (
+                f"[System: Profile fields unset and relevant: {unasked}. "
+                "Infer from user message if possible and call save_profile_field. "
+                "Otherwise ask for at most one.]"
+            )
+            history[-1]["content"] = history[-1]["content"] + "\n\n" + note
+            mem_session.asked_this_session.update(unasked)
+
         registry = ToolRegistry()
+        registry.register(
+            "save_profile_field",
+            save_profile_field_handler,
+            SAVE_PROFILE_FIELD_SCHEMA,
+        )
 
         try:
             client = get_client()

--- a/src/weles/tools/profile_tools.py
+++ b/src/weles/tools/profile_tools.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+from weles.db.profile_repo import update_profile
+
+_VALID_FIELDS = {
+    "height_cm",
+    "weight_kg",
+    "build",
+    "fitness_level",
+    "injury_history",
+    "dietary_restrictions",
+    "dietary_preferences",
+    "dietary_approach",
+    "aesthetic_style",
+    "brand_rejections",
+    "climate",
+    "activity_level",
+    "living_situation",
+    "country",
+    "budget_psychology",
+    "fitness_goal",
+    "dietary_goal",
+    "lifestyle_focus",
+}
+
+SAVE_PROFILE_FIELD_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "field": {
+            "type": "string",
+            "description": "Profile field name to update.",
+        },
+        "value": {
+            "type": "string",
+            "description": "New value for the field.",
+        },
+    },
+    "required": ["field", "value"],
+}
+
+
+def save_profile_field(field: str, value: str) -> str:
+    """Save a single profile field. Raises ValueError for unknown fields."""
+    if field not in _VALID_FIELDS:
+        raise ValueError(f"Unknown profile field: {field!r}")
+    update_profile({field: value})
+    return f"Saved {field} = {value!r}"
+
+
+def save_profile_field_handler(tool_input: dict[str, Any]) -> str:
+    return save_profile_field(tool_input["field"], tool_input["value"])

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,0 +1,22 @@
+from weles.agent.context import check_missing_fields
+from weles.profile.models import UserProfile
+
+
+def test_shopping_empty_profile_returns_all_fields() -> None:
+    result = check_missing_fields("shopping", UserProfile())
+    assert result == ["budget_psychology", "aesthetic_style", "country"]
+
+
+def test_shopping_one_field_set_excludes_it() -> None:
+    result = check_missing_fields("shopping", UserProfile(budget_psychology="good_enough"))
+    assert result == ["aesthetic_style", "country"]
+
+
+def test_general_always_returns_empty() -> None:
+    result = check_missing_fields("general", UserProfile())
+    assert result == []
+
+
+def test_diet_one_field_set_returns_other() -> None:
+    result = check_missing_fields("diet", UserProfile(dietary_restrictions="gluten"))
+    assert result == ["dietary_approach"]

--- a/tests/unit/test_dispatch.py
+++ b/tests/unit/test_dispatch.py
@@ -7,7 +7,9 @@ from weles.utils.errors import ToolNotFoundError
 def test_register_and_dispatch_calls_handler():
     registry = ToolRegistry()
     registry.register("my_tool", lambda inp: "result", {"type": "object", "properties": {}})
-    assert registry.dispatch("my_tool", {}) == "result"
+    result = registry.dispatch("my_tool", {})
+    assert result.summary == "result"
+    assert result.data == "result"
 
 
 def test_dispatch_unknown_tool_raises():

--- a/tests/unit/test_save_profile_field.py
+++ b/tests/unit/test_save_profile_field.py
@@ -1,0 +1,14 @@
+import pytest
+
+from weles.tools.profile_tools import save_profile_field
+
+
+def test_save_profile_field_calls_update_profile(mocker) -> None:  # type: ignore[no-untyped-def]
+    mock_update = mocker.patch("weles.tools.profile_tools.update_profile")
+    save_profile_field("fitness_level", "beginner")
+    mock_update.assert_called_once_with({"fitness_level": "beginner"})
+
+
+def test_save_profile_field_unknown_field_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown profile field"):
+        save_profile_field("unknown_field", "x")

--- a/tests/unit/test_stream_events.py
+++ b/tests/unit/test_stream_events.py
@@ -1,0 +1,83 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from anthropic.types import RawMessageStopEvent, ToolUseBlock
+
+from weles.agent.dispatch import ToolRegistry
+from weles.agent.stream import (
+    DoneEvent,
+    ToolErrorEvent,
+    ToolStartEvent,
+    stream_response,
+)
+from weles.api.routers.messages import _agent_event_to_sse
+
+
+def test_tool_start_event_serialises_to_tool_start_sse():
+    description = "Searching r/BuyItForLife for 'knife'…"
+    event = ToolStartEvent(tool="search_reddit", description=description)
+    sse = _agent_event_to_sse(event, "title", "session-id")
+    assert sse is not None
+    assert sse["event"] == "tool_start"
+    payload = json.loads(sse["data"])
+    assert payload["tool"] == "search_reddit"
+    assert payload["description"] == "Searching r/BuyItForLife for 'knife'…"
+
+
+def test_tool_error_event_serialises_to_tool_error_sse():
+    event = ToolErrorEvent(tool="search_reddit", error="Request timed out")
+    sse = _agent_event_to_sse(event, "title", "session-id")
+    assert sse is not None
+    assert sse["event"] == "tool_error"
+    payload = json.loads(sse["data"])
+    assert payload["tool"] == "search_reddit"
+    assert payload["error"] == "Request timed out"
+
+
+@pytest.mark.asyncio
+async def test_tool_dispatch_exception_emits_tool_error_does_not_reraise():
+    """When a registered handler raises, ToolErrorEvent is emitted; stream does not abort."""
+
+    def bad_handler(_: dict) -> str:
+        raise ValueError("boom")
+
+    # First Claude response: stop_reason=tool_use with one tool use block
+    first_stream = MagicMock()
+    first_stream.__enter__ = MagicMock(return_value=first_stream)
+    first_stream.__exit__ = MagicMock(return_value=False)
+    first_stream.__iter__ = MagicMock(return_value=iter([]))
+    first_message = MagicMock()
+    first_message.stop_reason = "tool_use"
+    first_message.content = [
+        ToolUseBlock(id="tu_1", name="bad_tool", input={"x": 1}, type="tool_use")
+    ]
+    first_stream.get_final_message = MagicMock(return_value=first_message)
+
+    # Second Claude response: stop_reason=end_turn, no tool calls
+    second_stream = MagicMock()
+    second_stream.__enter__ = MagicMock(return_value=second_stream)
+    second_stream.__exit__ = MagicMock(return_value=False)
+    second_stream.__iter__ = MagicMock(
+        return_value=iter([RawMessageStopEvent(type="message_stop")])
+    )
+    second_message = MagicMock()
+    second_message.stop_reason = "end_turn"
+    second_message.content = []
+    second_stream.get_final_message = MagicMock(return_value=second_message)
+
+    mock_client = MagicMock()
+    mock_client.messages.stream.side_effect = [first_stream, second_stream]
+
+    registry = ToolRegistry()
+    registry.register("bad_tool", bad_handler, {"type": "object", "properties": {}})
+
+    events = []
+    async for event in stream_response(mock_client, [], [], [], registry):
+        events.append(event)
+
+    error_events = [e for e in events if isinstance(e, ToolErrorEvent)]
+    assert len(error_events) == 1
+    assert error_events[0].tool == "bad_tool"
+    assert "boom" in error_events[0].error
+    assert isinstance(events[-1], DoneEvent)


### PR DESCRIPTION
## Issue

Closes #13

## What this PR does

Implements the agentic tool-use loop in `stream_response` with typed SSE progress events emitted around every tool dispatch.

## Acceptance criteria

- [x] `stream.py` emits `ToolStartEvent`, `ToolEndEvent`, `ToolErrorEvent` around every `dispatch()` call
- [x] `ToolStartEvent.description` human-readable per tool: `search_reddit`, `search_web`, `add_to_history`, `save_profile_field`, generic fallback
- [x] `ToolEndEvent.result_summary` populated from `ToolResult.summary` returned by each handler
- [x] `ToolErrorEvent.error` contains the exception message; dispatch catches all exceptions and emits this event rather than propagating
- [x] Claude told on tool error: `"Tool {name} failed: {error}. Continue with available data; note the limitation in your response."`
- [x] Frontend collapsible activity strip already present from #5; `tool_start`/`tool_end`/`tool_error` SSE fields now populated correctly

## Tests

- [x] All tests specified in the issue are present (`tests/unit/test_stream_events.py`)
- [x] `make lint` passes
- [x] `make test` passes (55 tests)
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (if endpoints changed) — SSE event format unchanged; no update needed
- [ ] `docs/architecture.md` updated (if patterns or module boundaries changed) — no module boundary changes

## Notes

`ToolResult(summary, data)` named tuple added to `dispatch.py`. Existing string-returning handlers are coerced automatically (`summary=str(result), data=str(result)`), so no handler changes are needed. The agentic loop lives entirely in `stream_response` — the router now passes `registry` as a fifth argument and the loop runs until `stop_reason == "end_turn"`.