### PR TITLE
feat: #9 Information tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `GET /history?domain=&status=` and `DELETE /history/{id}` endpoints (previously stub, now fully wired) (#12)
 - History page in frontend: filterable table by domain and status, per-row delete button (#12)
 
-<!-- Issue #9 -->
+- Information page: profile fields (inline edit, decay indicator, last-updated date), learned preferences (delete), history summary by domain and status (#9)
+- `GET /preferences` endpoint to list all learned preferences (#9)
 
 ### v0.3 — Research Engine
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,222 @@
+# API Reference
+
+> Keep this document current. Update it when any issue adds, removes, or changes an endpoint.
+
+Base URL (dev): `http://localhost:8000`
+
+---
+
+## Health
+
+### `GET /health`
+Returns app state flags.
+
+**Response `200`**
+```json
+{
+  "status": "ok",
+  "web_search": true,
+  "first_run": false
+}
+```
+
+- `web_search`: false when `TAVILY_API_KEY` is absent
+- `first_run`: true when `profile.first_session_at IS NULL`
+
+---
+
+## Sessions
+
+### `POST /sessions`
+Create a new chat session. Runs session-start checks.
+
+**Response `201`**
+```json
+{
+  "id": "uuid",
+  "title": null,
+  "mode": "general",
+  "created_at": "ISO datetime",
+  "session_start_prompt": null
+}
+```
+
+- `title`: null until first user message is saved (set to first 50 chars)
+- `session_start_prompt`: null until Issue #24 (orchestrator) is implemented; field present from Issue #5
+
+### `GET /sessions`
+List all sessions, most recent first.
+
+**Response `200`** — array of:
+```json
+{
+  "id": "uuid",
+  "title": "string or null",
+  "mode": "general|shopping|diet|fitness|lifestyle",
+  "created_at": "ISO datetime",
+  "preview": "first 60 chars of first user message, or null"
+}
+```
+
+### `PATCH /sessions/{id}`
+Update session title or mode.
+
+**Request body** (all fields optional):
+```json
+{ "title": "string", "mode": "shopping" }
+```
+
+**Response `200`** — updated session object
+
+**Errors:** `404` session not found; `422` invalid mode
+
+### `DELETE /sessions/{id}`
+Delete session and all its messages (cascade).
+
+**Response `204`**
+
+---
+
+## Messages
+
+### `POST /sessions/{id}/messages`
+Send a message. Returns SSE stream.
+
+**Request body:**
+```json
+{ "content": "string" }
+```
+
+**Response `200`** — `Content-Type: text/event-stream`
+
+SSE event types:
+```
+event: text_delta     data: {"delta": "..."}
+event: tool_start     data: {"tool": "search_reddit", "description": "Searching r/BuyItForLife..."}
+event: tool_end       data: {"tool": "search_reddit", "result_summary": "Found 8 posts"}
+event: tool_error     data: {"tool": "search_reddit", "error": "Request timed out"}
+event: done           data: {"session_id": "uuid", "title": "string"}
+event: error          data: {"message": "Claude API unavailable"}
+```
+
+`tool_error` is non-fatal — stream continues. `error` terminates the stream.
+
+### `GET /sessions/{id}/messages`
+Retrieve full message history for a session.
+
+**Response `200`** — array of:
+```json
+{
+  "id": "uuid",
+  "session_id": "uuid",
+  "role": "user|assistant|tool_result",
+  "content": "string",
+  "tool_name": "string or null",
+  "is_compressed": false,
+  "created_at": "ISO datetime"
+}
+```
+
+---
+
+## Profile
+
+### `GET /profile`
+Return full user profile. All nullable fields included (not omitted).
+
+**Response `200`** — `UserProfile` object (all fields, nulls included)
+
+### `PATCH /profile`
+Partial update. Updates `field_timestamps` atomically with each changed field.
+
+**Request body** — any subset of profile fields:
+```json
+{
+  "fitness_level": "beginner",
+  "weight_kg": 80.0,
+  "dietary_restrictions": ["gluten"]
+}
+```
+
+**Response `200`** — updated profile
+
+**Errors:** `422` unknown field name; `422` invalid enum value
+
+---
+
+## History
+
+### `GET /history`
+List history items, most recent first.
+
+**Query params** (all optional):
+- `domain`: `shopping|diet|fitness|lifestyle`
+- `status`: `recommended|bought|tried|rated|skipped`
+
+**Response `200`** — array of history items
+
+### `DELETE /history/{id}`
+Delete a history item.
+
+**Response `204`**
+
+---
+
+## Preferences
+
+### `GET /preferences`
+List all learned preferences, oldest first.
+
+**Response `200`** — array of:
+```json
+{
+  "id": "uuid",
+  "dimension": "string",
+  "value": "string",
+  "reason": "string or null",
+  "source": "string",
+  "created_at": "ISO datetime or null"
+}
+```
+
+### `DELETE /preferences/{id}`
+Delete a learned preference. Agent reverts to prior behaviour for that dimension.
+
+**Response `204`**
+
+---
+
+## Settings
+
+### `GET /settings`
+Return all settings as a flat key-value map.
+
+**Response `200`**
+```json
+{
+  "follow_up_cadence": "off",
+  "proactive_surfacing": "true",
+  "decay_thresholds": {"goals": 60, "fitness_level": 90, "dietary_approach": 90, "body_metrics": 180, "taste_lifestyle": 365},
+  "max_tool_calls_per_turn": "6"
+}
+```
+
+### `PATCH /settings`
+Partial update. Rejects unknown keys.
+
+**Request body** — any subset of known settings keys
+
+**Response `200`** — updated settings map
+
+**Errors:** `422` unknown key
+
+---
+
+## Data
+
+### `DELETE /data`
+Wipe all user data. Runs `alembic downgrade base` then `alembic upgrade head`.
+
+**Response `204`**
+
+Used by the Settings page "Clear all data" button.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -228,6 +228,49 @@ body {
 .confirm-modal button:first-of-type { background: #5a2020; border-color: #6a2525; }
 .cleared-notice { color: #6a9; font-size: 13px; margin-bottom: 8px; }
 
+/* ── Information page ── */
+.info-page { max-width: 700px; margin: 40px auto; padding: 0 24px; }
+.info-page h1 { margin-bottom: 24px; }
+.info-section { margin-bottom: 28px; border-bottom: 1px solid #2e2e2e; padding-bottom: 20px; }
+.info-section h2 { font-size: 13px; color: #888; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 10px; }
+.info-field {
+  display: flex; align-items: center; gap: 10px; padding: 6px 8px; border-radius: 5px;
+  cursor: pointer; font-size: 13px;
+}
+.info-field:hover { background: #1a1a1a; }
+.info-field.editing { background: #1a1a1a; cursor: default; }
+.info-field-label { width: 180px; flex-shrink: 0; color: #888; }
+.info-field-value { flex: 1; color: #e8e8e8; }
+.info-field-value.unset { color: #444; font-style: italic; }
+.info-field-meta { display: flex; align-items: center; gap: 6px; margin-left: auto; }
+.info-field-date { color: #555; font-size: 11px; }
+.stale-dot { color: #c8963a; font-size: 9px; cursor: help; }
+.info-field input, .info-field select {
+  background: #222; border: 1px solid #444; color: #e8e8e8; border-radius: 4px;
+  padding: 3px 7px; font-size: 13px; flex: 1;
+}
+.info-field input:focus, .info-field select:focus { outline: none; border-color: #666; }
+.info-empty { color: #555; font-size: 13px; font-style: italic; }
+.info-pref-row {
+  display: flex; align-items: center; gap: 10px; padding: 6px 8px;
+  border-radius: 5px; font-size: 13px;
+}
+.info-pref-row:hover { background: #1a1a1a; }
+.info-pref-dim { color: #888; width: 130px; flex-shrink: 0; }
+.info-pref-value { flex: 1; color: #e8e8e8; }
+.info-pref-reason { color: #666; font-size: 12px; max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.info-pref-source {
+  font-size: 11px; padding: 2px 6px; border-radius: 10px; flex-shrink: 0;
+  background: #2a2a2a; color: #888; border: 1px solid #3a3a3a;
+}
+.source-conversation { border-color: #2a4a7a; color: #6a9fca; }
+.source-inferred { border-color: #3a4a2a; color: #8aaa6a; }
+.info-history-row { display: flex; gap: 12px; padding: 4px 8px; font-size: 13px; }
+.info-history-domain { color: #888; width: 100px; flex-shrink: 0; text-transform: capitalize; }
+.info-history-counts { color: #ccc; }
+.info-history-link { background: none; border: none; color: #6a9fca; font-size: 13px; cursor: pointer; padding: 6px 8px; margin-top: 4px; }
+.info-history-link:hover { color: #8abfea; }
+
 /* ── History page ── */
 .history-page { max-width: 900px; margin: 40px auto; padding: 0 24px; }
 .history-page h1 { margin-bottom: 24px; }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { clearData, createSession, deleteHistoryItem, deleteSession, getSettings, listHistory, listSessions, patchSession, patchSettings } from './api'
-import type { ChatMessage, HistoryItem, Mode, Session, ToolProgress } from './types'
+import { clearData, createSession, deleteHistoryItem, deletePreference, deleteSession, getProfile, getSettings, listHistory, listPreferences, listSessions, patchProfile, patchSession, patchSettings } from './api'
+import type { ChatMessage, HistoryItem, Mode, Preference, Session, ToolProgress, UserProfile } from './types'
 import './App.css'
 
 const MODES: Mode[] = ['general', 'shopping', 'diet', 'fitness', 'lifestyle']
@@ -121,6 +121,223 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
           </div>
         ) : (
           <button className="danger-btn" onClick={() => setConfirmClear(true)}>Clear all data</button>
+        )}
+      </section>
+    </div>
+  )
+}
+
+// ── Information page ──────────────────────────────────────────────────────
+
+type DecayThresholds = Record<string, number>
+
+const FIELD_DECAY_CATEGORY: Record<string, keyof DecayThresholds> = {
+  fitness_goal: 'goals', dietary_goal: 'goals', lifestyle_focus: 'goals',
+  fitness_level: 'fitness_level',
+  dietary_approach: 'dietary_approach',
+  height_cm: 'body_metrics', weight_kg: 'body_metrics', build: 'body_metrics',
+  aesthetic_style: 'taste_lifestyle', brand_rejections: 'taste_lifestyle',
+  climate: 'taste_lifestyle', activity_level: 'taste_lifestyle',
+  living_situation: 'taste_lifestyle', country: 'taste_lifestyle',
+  budget_psychology: 'taste_lifestyle', injury_history: 'taste_lifestyle',
+  dietary_restrictions: 'taste_lifestyle', dietary_preferences: 'taste_lifestyle',
+}
+
+const FIELD_ENUMS: Record<string, string[]> = {
+  build: ['lean', 'athletic', 'average', 'heavy'],
+  fitness_level: ['sedentary', 'beginner', 'intermediate', 'advanced'],
+  dietary_approach: ['keto', 'vegan', 'omnivore', 'carnivore', 'flexible'],
+  aesthetic_style: ['minimal', 'technical', 'classic', 'mixed'],
+  budget_psychology: ['buy_once_buy_right', 'good_enough', 'context_dependent'],
+  activity_level: ['low', 'moderate', 'high'],
+  living_situation: ['urban', 'suburban', 'rural'],
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  height_cm: 'Height (cm)', weight_kg: 'Weight (kg)', build: 'Build',
+  fitness_level: 'Fitness level', injury_history: 'Injury history',
+  dietary_restrictions: 'Dietary restrictions', dietary_preferences: 'Dietary preferences',
+  dietary_approach: 'Dietary approach', aesthetic_style: 'Aesthetic style',
+  brand_rejections: 'Brand rejections', climate: 'Climate', country: 'Country',
+  activity_level: 'Activity level', living_situation: 'Living situation',
+  budget_psychology: 'Budget psychology', fitness_goal: 'Fitness goal',
+  dietary_goal: 'Dietary goal', lifestyle_focus: 'Lifestyle focus',
+}
+
+const INFO_SECTIONS: { title: string; fields: string[] }[] = [
+  { title: 'Identity & Body', fields: ['height_cm', 'weight_kg', 'build', 'fitness_level', 'injury_history'] },
+  { title: 'Diet', fields: ['dietary_restrictions', 'dietary_preferences', 'dietary_approach'] },
+  { title: 'Style & Taste', fields: ['aesthetic_style', 'brand_rejections'] },
+  { title: 'Lifestyle', fields: ['climate', 'country', 'activity_level', 'living_situation'] },
+  { title: 'Budget', fields: ['budget_psychology'] },
+  { title: 'Goals', fields: ['fitness_goal', 'dietary_goal', 'lifestyle_focus'] },
+]
+
+function isStale(field: string, timestamps: Record<string, string>, thresholds: DecayThresholds): boolean {
+  const ts = timestamps[field]
+  if (!ts) return false
+  const category = FIELD_DECAY_CATEGORY[field]
+  if (!category) return false
+  const days = thresholds[category]
+  if (!days) return false
+  return Date.now() - Date.parse(ts) > days * 86400000
+}
+
+function daysSince(iso: string): number {
+  return Math.floor((Date.now() - Date.parse(iso)) / 86400000)
+}
+
+function ProfileField({
+  field, value, timestamp, stale, onSave,
+}: {
+  field: string
+  value: string | null
+  timestamp: string | null
+  stale: boolean
+  onSave: (field: string, value: string) => Promise<void>
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value ?? '')
+  const enumOptions = FIELD_ENUMS[field]
+
+  async function save() {
+    if (draft.trim() === (value ?? '')) { setEditing(false); return }
+    await onSave(field, draft.trim())
+    setEditing(false)
+  }
+
+  if (editing) {
+    return (
+      <div className="info-field editing">
+        <span className="info-field-label">{FIELD_LABELS[field]}</span>
+        {enumOptions ? (
+          <select
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            onBlur={save}
+            autoFocus
+          >
+            <option value="">— not set —</option>
+            {enumOptions.map(o => <option key={o} value={o}>{o}</option>)}
+          </select>
+        ) : (
+          <input
+            type={field === 'height_cm' || field === 'weight_kg' ? 'number' : 'text'}
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            onBlur={save}
+            onKeyDown={e => { if (e.key === 'Enter') save(); if (e.key === 'Escape') setEditing(false) }}
+            autoFocus
+          />
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="info-field" onClick={() => { setDraft(value ?? ''); setEditing(true) }}>
+      <span className="info-field-label">{FIELD_LABELS[field]}</span>
+      <span className={`info-field-value${value ? '' : ' unset'}`}>{value ?? 'Not set'}</span>
+      <span className="info-field-meta">
+        {stale && <span className="stale-dot" title={`Last set ${daysSince(timestamp!)} days ago`}>●</span>}
+        {timestamp && <span className="info-field-date">{timestamp.slice(0, 10)}</span>}
+      </span>
+    </div>
+  )
+}
+
+function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHistory: () => void }) {
+  const [profile, setProfile] = useState<UserProfile | null>(null)
+  const [prefs, setPrefs] = useState<Preference[]>([])
+  const [history, setHistory] = useState<HistoryItem[]>([])
+  const [thresholds, setThresholds] = useState<DecayThresholds>({})
+
+  useEffect(() => {
+    Promise.all([getProfile(), listPreferences(), listHistory(), getSettings()]).then(
+      ([p, pr, h, s]) => {
+        setProfile(p)
+        setPrefs(pr)
+        setHistory(h)
+        setThresholds((s.decay_thresholds as DecayThresholds) ?? {})
+      }
+    )
+  }, [])
+
+  async function saveField(field: string, value: string) {
+    const updated = await patchProfile({ [field]: value || null })
+    setProfile(updated)
+  }
+
+  async function handleDeletePref(id: string) {
+    await deletePreference(id)
+    setPrefs(prev => prev.filter(p => p.id !== id))
+  }
+
+  const timestamps: Record<string, string> = profile?.field_timestamps
+    ? JSON.parse(profile.field_timestamps)
+    : {}
+
+  // History summary: count per domain per status
+  const historySummary: Record<string, Record<string, number>> = {}
+  for (const item of history) {
+    if (!historySummary[item.domain]) historySummary[item.domain] = {}
+    historySummary[item.domain][item.status] = (historySummary[item.domain][item.status] ?? 0) + 1
+  }
+
+  if (!profile) return <div className="info-page"><button className="back-btn" onClick={onBack}>← Back</button><p>Loading…</p></div>
+
+  return (
+    <div className="info-page">
+      <button className="back-btn" onClick={onBack}>← Back</button>
+      <h1>Information</h1>
+
+      {INFO_SECTIONS.map(section => (
+        <section key={section.title} className="info-section">
+          <h2>{section.title}</h2>
+          {section.fields.map(field => (
+            <ProfileField
+              key={field}
+              field={field}
+              value={(profile as unknown as Record<string, string | null>)[field]}
+              timestamp={timestamps[field] ?? null}
+              stale={isStale(field, timestamps, thresholds)}
+              onSave={saveField}
+            />
+          ))}
+        </section>
+      ))}
+
+      <section className="info-section">
+        <h2>Learned Preferences</h2>
+        {prefs.length === 0
+          ? <p className="info-empty">No learned preferences yet.</p>
+          : prefs.map(pref => (
+            <div key={pref.id} className="info-pref-row">
+              <span className="info-pref-dim">{pref.dimension}</span>
+              <span className="info-pref-value">{pref.value}</span>
+              {pref.reason && <span className="info-pref-reason">{pref.reason}</span>}
+              <span className={`info-pref-source source-${pref.source}`}>{pref.source}</span>
+              <button className="del-btn" onClick={() => handleDeletePref(pref.id)}>×</button>
+            </div>
+          ))
+        }
+      </section>
+
+      <section className="info-section">
+        <h2>History Summary</h2>
+        {Object.keys(historySummary).length === 0
+          ? <p className="info-empty">No history yet.</p>
+          : Object.entries(historySummary).map(([domain, counts]) => (
+            <div key={domain} className="info-history-row">
+              <span className="info-history-domain">{domain}</span>
+              <span className="info-history-counts">
+                {Object.entries(counts).map(([status, n]) => `${n} ${status}`).join(', ')}
+              </span>
+            </div>
+          ))
+        }
+        {history.length > 0 && (
+          <button className="info-history-link" onClick={onGoHistory}>View full history →</button>
         )}
       </section>
     </div>
@@ -361,6 +578,10 @@ export default function App() {
 
   if (page === 'settings') {
     return <SettingsPage onBack={() => setPage('chat')} />
+  }
+
+  if (page === 'info') {
+    return <InformationPage onBack={() => setPage('chat')} onGoHistory={() => setPage('history')} />
   }
 
   if (page === 'history') {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Mode, Session } from './types'
+import type { HistoryItem, Mode, Preference, Session, UserProfile } from './types'
 
 export async function createSession(): Promise<Session> {
   const r = await fetch('/sessions', { method: 'POST' })
@@ -37,6 +37,29 @@ export async function patchSettings(patch: Record<string, unknown>): Promise<Rec
   return r.json()
 }
 
+export async function getProfile(): Promise<UserProfile> {
+  const r = await fetch('/profile')
+  return r.json()
+}
+
+export async function patchProfile(patch: Record<string, unknown>): Promise<UserProfile> {
+  const r = await fetch('/profile', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+  return r.json()
+}
+
+export async function listPreferences(): Promise<Preference[]> {
+  const r = await fetch('/preferences')
+  return r.json()
+}
+
+export async function deletePreference(id: string): Promise<void> {
+  await fetch(`/preferences/${id}`, { method: 'DELETE' })
+}
+
 export async function clearData(): Promise<void> {
   const r = await fetch('/data', { method: 'DELETE' })
   if (!r.ok) throw new Error(`DELETE /data failed: ${r.status}`)
@@ -55,4 +78,4 @@ export async function deleteHistoryItem(id: string): Promise<void> {
   await fetch(`/history/${id}`, { method: 'DELETE' })
 }
 
-export type { HistoryItem } from './types'
+export type { HistoryItem, Preference, UserProfile } from './types'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -32,6 +32,39 @@ export interface ChatMessage {
   streaming?: boolean
 }
 
+export interface UserProfile {
+  id: number | null
+  height_cm: number | null
+  weight_kg: number | null
+  build: string | null
+  fitness_level: string | null
+  injury_history: string | null
+  dietary_restrictions: string | null
+  dietary_preferences: string | null
+  dietary_approach: string | null
+  aesthetic_style: string | null
+  brand_rejections: string | null
+  climate: string | null
+  activity_level: string | null
+  living_situation: string | null
+  country: string | null
+  budget_psychology: string | null
+  fitness_goal: string | null
+  dietary_goal: string | null
+  lifestyle_focus: string | null
+  first_session_at: string | null
+  field_timestamps: string | null
+}
+
+export interface Preference {
+  id: string
+  dimension: string
+  value: string
+  reason: string | null
+  source: string
+  created_at: string | null
+}
+
 export interface HistoryItem {
   id: string
   item_name: string

--- a/src/weles/api/routers/preferences.py
+++ b/src/weles/api/routers/preferences.py
@@ -1,8 +1,17 @@
+from typing import Any
+
 from fastapi import APIRouter, HTTPException
 
 from weles.db.connection import get_db
 
 router = APIRouter(prefix="/preferences", tags=["preferences"])
+
+
+@router.get("")
+async def list_preferences() -> list[dict[str, Any]]:
+    conn = get_db()
+    rows = conn.execute("SELECT * FROM preferences ORDER BY created_at ASC").fetchall()
+    return [dict(row) for row in rows]
 
 
 @router.delete("/{pref_id}", status_code=204)


### PR DESCRIPTION
## Issue

Closes #9

## What this PR does

Adds the Information page — a transparency view showing all profile fields (inline editable, with decay indicators), learned preferences (deletable), and a history summary by domain and status.

## Acceptance criteria

- [x] Route `/information` in frontend; sidebar link "Information"
- [x] **Identity & Body** section: height, weight, build, fitness level, injury history
- [x] **Diet** section: restrictions, preferences, approach
- [x] **Style & Taste** section: aesthetic style, brand rejections
- [x] **Lifestyle** section: climate, country, activity level, living situation
- [x] **Budget** section: budget psychology
- [x] **Goals** section: fitness goal, dietary goal, lifestyle focus
- [x] **Learned Preferences** section: value, reason, source badge, delete button per row
- [x] **History Summary** section: count per domain per status; link to history page
- [x] Each profile field shows current value or "Not set" (muted)
- [x] Each profile field shows last updated date from `field_timestamps`
- [x] Amber dot indicator if past decay threshold; tooltip shows days since set
- [x] Click to inline edit — text input or dropdown for enums; Enter/blur saves via `PATCH /profile`

## Tests

- [x] No backend tests needed per issue spec
- [x] `make lint` passes
- [x] `make test` passes (64 tests)
- [x] TypeScript compiles without errors (`tsc --noEmit`)

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `docs/api.md` updated — added `GET /preferences` (new endpoint added to support the preferences list)
- [ ] `docs/architecture.md` — no core pattern changes

## Notes

Added `GET /preferences` to `preferences.py` — required to populate the Learned Preferences section. Previously only `DELETE /preferences/{id}` existed.