### PR TITLE
feat: #14 Reddit search tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Human-readable `ToolStartEvent.description` per tool: `search_reddit`, `search_web`, `add_to_history`, `save_profile_field`, and a generic fallback (#13)
 - Tool exceptions caught in the loop and emitted as `ToolErrorEvent`; Claude instructed to continue with available data (#13)
 
-<!-- Issues #14–18 -->
+- `search_reddit` Claude tool: searches Reddit via public JSON API; no credentials required; supports per-subreddit scoping, deduplication, and top-3 comments (#14)
+- Rate limiting: `asyncio.Semaphore(1)` + 1 s sleep after every request; 429 backoff using `Retry-After`; 3 retries before `RedditUnavailableError` (#14)
+- Posts with score < 5 excluded; results sorted by score descending (#14)
+- `max_tool_calls_per_turn` enforced in `ToolRegistry`: reads from settings (default 6); 7th call in a turn raises `MaxToolCallsError` → `ToolErrorEvent` (#14)
+
+<!-- Issues #15–18 -->
 
 ### v0.4 — Domain Modules
 <!-- Issues #19–22 -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,136 @@
+# Architecture
+
+> Keep this document current. Update it when any issue changes a core pattern, data flow, or module boundary.
+
+---
+
+## Overview
+
+Weles is a single-user, locally-hosted AI agent. FastAPI serves both the API and the built React frontend from a single process. In production (and as a `.exe`) there is no Node.js process — the frontend is a static build mounted at `/`.
+
+```
+Browser  ←→  FastAPI (uvicorn)  ←→  Claude API
+                  |
+               SQLite
+            (~/.weles/weles.db)
+```
+
+---
+
+## Request lifecycle — chat message
+
+1. `POST /sessions/{id}/messages` received with `{content, mode}`
+2. **Session start checks** run on first message only (via `run_session_start_checks`)
+3. `first_session_at` written to `profile` if null (first-ever message)
+4. `Session.get_messages_for_context()` assembles history (compressed messages substituted)
+5. `build_system_prompt(mode, profile, preferences)` builds the Anthropic `system` array:
+   - Block 1: `prompts/system.md` (always)
+   - Block 2: `prompts/modes/{mode}.md` (if mode ≠ general)
+   - Block 3: serialised profile + preferences (if non-empty)
+6. Missing profile fields for this mode appended to user turn as `[System: ...]` note
+7. History context for this domain appended to user turn
+8. `stream_response(client, messages, tools, system)` called → yields `AgentEvent`s
+9. Each `AgentEvent` serialised to SSE and flushed to browser immediately
+10. Tool calls dispatched via `ToolRegistry.dispatch()`; `max_tool_calls_per_turn` enforced
+11. On turn completion: tool results compressed async (fire-and-forget); session saved to DB
+
+---
+
+## Module map
+
+| Module | Responsibility |
+|---|---|
+| `agent/client.py` | `get_client() -> AsyncAnthropic`; reads env |
+| `agent/stream.py` | `stream_response()` → `AsyncIterator[AgentEvent]`; owns the Anthropic streaming loop |
+| `agent/dispatch.py` | `ToolRegistry`: register, dispatch, schema export; enforces tool call cap |
+| `agent/session.py` | `Session`: message list, compression, token estimation |
+| `agent/prompts.py` | `build_system_prompt(mode, profile, preferences)` |
+| `agent/context.py` | `check_missing_fields(mode, profile)` |
+| `api/main.py` | FastAPI app; lifespan wires `startup()`; mounts `frontend/dist/` in production |
+| `api/startup.py` | `startup()`: env validation, DB migration, app state flags |
+| `api/session_start.py` | `run_session_start_checks()` orchestrator + individual check functions |
+| `api/routers/` | One router per resource group (sessions, profile, history, settings, data) |
+| `db/connection.py` | `get_db()`: WAL-mode SQLite connection, cached per thread |
+| `db/profile_repo.py` | `get_profile()`, `update_profile()`, `get_preferences()` |
+| `db/history_repo.py` | `add_to_history()`, `get_history_context()`, `get_history()` |
+| `db/settings_repo.py` | `get_setting()`, `set_setting()`, `get_all_settings()` |
+| `profile/models.py` | `UserProfile` Pydantic model; all enums |
+| `profile/context.py` | `build_profile_block()` → serialised string for system prompt |
+| `profile/decay.py` | `check_decay()` → stale field detection |
+| `research/credibility.py` | `score_result()` → `CredibilityLabel`; affiliate + astroturf detection |
+| `research/routing.py` | `get_subreddits(mode, subcategory)` from `config/subreddits.toml` |
+| `tools/reddit.py` | `search_reddit()` tool; httpx → Reddit public JSON API |
+| `tools/web.py` | `search_web()` tool; Tavily API; only registered when key present |
+| `tools/history_tools.py` | `add_to_history()` Claude tool |
+| `tools/profile_tools.py` | `save_profile_field()`, `update_preference()` Claude tools |
+| `utils/paths.py` | `resource_path()`: PyInstaller-safe file path resolution |
+| `utils/errors.py` | `ConfigurationError`, `ToolNotFoundError`, `RedditUnavailableError`, `MaxToolCallsError` |
+| `tray.py` | pystray system tray; starts uvicorn in daemon thread; Windows auto-start (#32) |
+
+---
+
+## Database schema
+
+Six tables. All created in one Alembic migration (`001_initial.py`). Never add columns mid-project — extend `001_initial.py` or add a new migration.
+
+| Table | Purpose |
+|---|---|
+| `sessions` | Chat sessions: id, title, mode, created_at |
+| `messages` | All messages: role, content, tool_name, is_compressed |
+| `profile` | Single row (id=1): all user profile fields + field_timestamps JSON |
+| `history` | Items recommended/bought/tried: follow_up_due_at, check_in_due_at |
+| `preferences` | Learned preferences: dimension, value, source (user_explicit / agent_inferred) |
+| `settings` | Key-value store: follow_up_cadence, proactive_surfacing, decay_thresholds, max_tool_calls_per_turn |
+
+---
+
+## Agent event types
+
+All yielded by `stream.py`, serialised to SSE by the router:
+
+```
+text_delta    {"delta": "..."}
+tool_start    {"tool": "...", "description": "..."}
+tool_end      {"tool": "...", "result_summary": "..."}
+tool_error    {"tool": "...", "error": "..."}
+done          {"session_id": "...", "title": "..."}
+error         {"message": "..."}
+```
+
+`tool_error` never aborts the stream. `error` (Claude API failure) does.
+
+---
+
+## Session start orchestrator
+
+`run_session_start_checks(db)` runs once per new session, in this exact order:
+
+1. Passive pattern detection — silent; writes `agent_inferred` preferences; no user prompt
+2. Profile decay check — if stale field found, sets `prompt`
+3. Follow-up check — if overdue follow-up AND no prompt yet, sets `prompt`
+4. Check-in check — if overdue check-in AND no prompt yet, sets `prompt`
+5. QC / proactive surfacing — always runs; adds to `notices` list regardless of prompt
+
+At most one `prompt` surfaces per session. `notices` are independent (shown as dismissable banners).
+
+---
+
+## PyInstaller constraints
+
+- **`resource_path(relative)`** must be used for every file read of config, prompts, blocklists, assets. It returns `Path(sys._MEIPASS) / relative` when frozen, else repo root.
+- `multiprocessing.freeze_support()` called at top of `tray.py` before any imports.
+- Frontend served as `StaticFiles` from `frontend/dist/` (bundled into the `.exe`).
+- API keys live in `~/.weles/.env` — never bundled.
+
+---
+
+## Key invariants
+
+| Invariant | Where enforced |
+|---|---|
+| `first_session_at` written on first-ever message | `api/routers/messages.py` |
+| At most 1 user-facing prompt per session start | `session_start.py` orchestrator |
+| Tool calls capped at `max_tool_calls_per_turn` (default 6) | `agent/dispatch.py` |
+| Tool errors never abort SSE stream | `agent/dispatch.py` |
+| Last 10 messages never compressed | `agent/session.py` |
+| All file reads use `resource_path` | `utils/paths.py` |

--- a/src/weles/agent/dispatch.py
+++ b/src/weles/agent/dispatch.py
@@ -1,7 +1,8 @@
+import inspect
 from collections.abc import Callable
 from typing import Any, NamedTuple
 
-from weles.utils.errors import ToolNotFoundError
+from weles.utils.errors import MaxToolCallsError, ToolNotFoundError
 
 
 class ToolResult(NamedTuple):
@@ -10,9 +11,11 @@ class ToolResult(NamedTuple):
 
 
 class ToolRegistry:
-    def __init__(self) -> None:
+    def __init__(self, max_calls: int = 6) -> None:
         self._handlers: dict[str, Callable[..., Any]] = {}
         self._schemas: dict[str, dict[str, Any]] = {}
+        self._max_calls = max_calls
+        self._call_count = 0
 
     def register(self, name: str, handler: Callable[..., Any], schema: dict[str, Any]) -> None:
         self._handlers[name] = handler
@@ -21,7 +24,24 @@ class ToolRegistry:
     def dispatch(self, tool_name: str, tool_input: dict[str, Any]) -> ToolResult:
         if tool_name not in self._handlers:
             raise ToolNotFoundError(f"Unknown tool: {tool_name!r}")
+        self._call_count += 1
+        if self._call_count > self._max_calls:
+            raise MaxToolCallsError(f"Research limit reached (max {self._max_calls})")
         result = self._handlers[tool_name](tool_input)
+        if isinstance(result, ToolResult):
+            return result
+        s = str(result)
+        return ToolResult(summary=s, data=s)
+
+    async def adispatch(self, tool_name: str, tool_input: dict[str, Any]) -> ToolResult:
+        if tool_name not in self._handlers:
+            raise ToolNotFoundError(f"Unknown tool: {tool_name!r}")
+        self._call_count += 1
+        if self._call_count > self._max_calls:
+            raise MaxToolCallsError(f"Research limit reached (max {self._max_calls})")
+        result = self._handlers[tool_name](tool_input)
+        if inspect.isawaitable(result):
+            result = await result
         if isinstance(result, ToolResult):
             return result
         s = str(result)

--- a/src/weles/agent/stream.py
+++ b/src/weles/agent/stream.py
@@ -108,7 +108,7 @@ async def stream_response(
             description = _build_description(tool_use.name, tool_use.input)
             yield ToolStartEvent(tool=tool_use.name, description=description)
             try:
-                result = registry.dispatch(tool_use.name, tool_use.input)
+                result = await registry.adispatch(tool_use.name, tool_use.input)
                 yield ToolEndEvent(tool=tool_use.name, result_summary=result.summary)
                 result_content = str(result.data)
             except Exception as exc:

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -25,8 +25,10 @@ from weles.agent.stream import (
 from weles.db.connection import get_db
 from weles.db.history_repo import get_history_context
 from weles.db.profile_repo import get_preferences, get_profile, set_first_session_at
+from weles.db.settings_repo import get_setting
 from weles.tools.history_tools import ADD_TO_HISTORY_SCHEMA, add_to_history_handler
 from weles.tools.profile_tools import SAVE_PROFILE_FIELD_SCHEMA, save_profile_field_handler
+from weles.tools.reddit import SEARCH_REDDIT_SCHEMA, search_reddit_handler
 from weles.utils.errors import ConfigurationError
 
 _MODE_TO_DOMAIN = {
@@ -141,7 +143,8 @@ async def post_message(session_id: str, body: MessageBody, request: Request) -> 
             if history_ctx:
                 history[-1]["content"] = history[-1]["content"] + "\n\n" + history_ctx
 
-        registry = ToolRegistry()
+        max_calls = int(get_setting("max_tool_calls_per_turn") or 6)
+        registry = ToolRegistry(max_calls=max_calls)
         registry.register(
             "save_profile_field",
             save_profile_field_handler,
@@ -151,6 +154,11 @@ async def post_message(session_id: str, body: MessageBody, request: Request) -> 
             "add_to_history",
             add_to_history_handler,
             ADD_TO_HISTORY_SCHEMA,
+        )
+        registry.register(
+            "search_reddit",
+            search_reddit_handler,
+            SEARCH_REDDIT_SCHEMA,
         )
 
         try:

--- a/src/weles/tools/reddit.py
+++ b/src/weles/tools/reddit.py
@@ -1,0 +1,192 @@
+import asyncio
+from typing import Any, TypedDict
+
+import httpx
+
+from weles.agent.dispatch import ToolResult
+from weles.utils.errors import RedditUnavailableError
+
+_SEMAPHORE = asyncio.Semaphore(1)
+_USER_AGENT = "Weles/0.1"
+_MAX_RETRIES = 3
+_BASE = "https://www.reddit.com"
+
+
+class RedditPost(TypedDict):
+    title: str
+    url: str
+    score: int
+    created_utc: float
+    subreddit: str
+    selftext_preview: str
+    top_comments: list[dict[str, Any]]
+
+
+async def _reddit_get(client: httpx.AsyncClient, url: str, params: dict[str, Any]) -> Any:
+    """Single URL fetch with rate-limit semaphore, 1 s sleep, and 429 backoff."""
+    for attempt in range(_MAX_RETRIES):
+        async with _SEMAPHORE:
+            try:
+                resp = await client.get(url, params=params)
+            except httpx.RequestError as exc:
+                await asyncio.sleep(1.0)
+                if attempt == _MAX_RETRIES - 1:
+                    raise RedditUnavailableError(str(exc)) from exc
+                continue
+
+            await asyncio.sleep(1.0)
+
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "10"))
+            await asyncio.sleep(retry_after)
+            continue
+
+        if resp.is_success:
+            return resp.json()
+
+        if attempt == _MAX_RETRIES - 1:
+            raise RedditUnavailableError(f"HTTP {resp.status_code} from {url}")
+
+    raise RedditUnavailableError(f"Reddit unavailable after {_MAX_RETRIES} attempts")
+
+
+def _parse_posts(data: dict[str, Any]) -> list[dict[str, Any]]:
+    posts: list[dict[str, Any]] = []
+    for child in data.get("data", {}).get("children", []):
+        d = child.get("data", {})
+        score = d.get("score", 0)
+        if score < 5:
+            continue
+        posts.append(
+            {
+                "title": d.get("title", ""),
+                "url": _BASE + d.get("permalink", d.get("url", "")),
+                "score": score,
+                "created_utc": float(d.get("created_utc", 0)),
+                "subreddit": d.get("subreddit", ""),
+                "selftext_preview": (d.get("selftext", "") or "")[:500],
+                "top_comments": [],
+                "_id": d.get("id", ""),
+                "_subreddit": d.get("subreddit", ""),
+            }
+        )
+    return posts
+
+
+def _parse_comments(data: Any) -> list[dict[str, Any]]:
+    if not isinstance(data, list) or len(data) < 2:
+        return []
+    children = data[1].get("data", {}).get("children", [])
+    comments: list[dict[str, Any]] = []
+    for child in children:
+        if child.get("kind") != "t1":
+            continue
+        d = child.get("data", {})
+        comments.append({"body": d.get("body", ""), "score": d.get("score", 0)})
+    comments.sort(key=lambda c: c["score"], reverse=True)
+    return comments[:3]
+
+
+async def _fetch_comments(
+    client: httpx.AsyncClient, posts: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for post in posts:
+        sub = post.get("_subreddit", "")
+        pid = post.get("_id", "")
+        if sub and pid:
+            try:
+                url = f"{_BASE}/r/{sub}/comments/{pid}.json"
+                data = await _reddit_get(client, url, {"limit": "5", "depth": "1", "raw_json": "1"})
+                comments = _parse_comments(data)
+            except (RedditUnavailableError, Exception):
+                comments = []
+        else:
+            comments = []
+        clean = {k: v for k, v in post.items() if not k.startswith("_")}
+        results.append({**clean, "top_comments": comments})
+    return results
+
+
+async def search_reddit(
+    query: str,
+    subreddits: list[str] | None = None,
+    limit: int = 10,
+    sort: str = "relevance",
+    time_filter: str = "year",
+) -> list[RedditPost]:
+    headers = {"User-Agent": _USER_AGENT}
+    base_params: dict[str, Any] = {
+        "q": query,
+        "sort": sort,
+        "t": time_filter,
+        "limit": str(limit),
+        "raw_json": "1",
+    }
+
+    async with httpx.AsyncClient(headers=headers) as client:
+        if subreddits:
+            seen_urls: set[str] = set()
+            extended: list[dict[str, Any]] = []
+            for sub in subreddits:
+                url = f"{_BASE}/r/{sub}/search.json"
+                data = await _reddit_get(client, url, {**base_params, "restrict_sr": "true"})
+                for post in _parse_posts(data):
+                    if post["url"] not in seen_urls:
+                        seen_urls.add(post["url"])
+                        extended.append(post)
+        else:
+            url = f"{_BASE}/search.json"
+            data = await _reddit_get(client, url, base_params)
+            extended = _parse_posts(data)
+
+        results = await _fetch_comments(client, extended)
+
+    results.sort(key=lambda p: p["score"], reverse=True)
+    return results  # type: ignore[return-value]
+
+
+SEARCH_REDDIT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string", "description": "Search query."},
+        "subreddits": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Optional subreddits to scope the search.",
+        },
+        "limit": {
+            "type": "integer",
+            "default": 10,
+            "description": "Max posts to return (default 10).",
+        },
+        "sort": {
+            "type": "string",
+            "enum": ["relevance", "hot", "top", "new"],
+            "default": "relevance",
+        },
+        "time_filter": {
+            "type": "string",
+            "enum": ["hour", "day", "week", "month", "year", "all"],
+            "default": "year",
+        },
+    },
+    "required": ["query"],
+}
+
+
+async def search_reddit_handler(tool_input: dict[str, Any]) -> ToolResult:
+    posts = await search_reddit(
+        query=tool_input["query"],
+        subreddits=tool_input.get("subreddits"),
+        limit=tool_input.get("limit", 10),
+        sort=tool_input.get("sort", "relevance"),
+        time_filter=tool_input.get("time_filter", "year"),
+    )
+    if not posts:
+        return ToolResult(summary="No posts found.", data=[])
+    top_score = posts[0]["score"]
+    return ToolResult(
+        summary=f"Found {len(posts)} posts (top score: {top_score})",
+        data=posts,
+    )

--- a/src/weles/utils/errors.py
+++ b/src/weles/utils/errors.py
@@ -4,3 +4,11 @@ class ConfigurationError(Exception):
 
 class ToolNotFoundError(Exception):
     pass
+
+
+class RedditUnavailableError(Exception):
+    pass
+
+
+class MaxToolCallsError(Exception):
+    pass

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -1,0 +1,129 @@
+import pytest
+from pytest_httpx import HTTPXMock
+
+from weles.tools.reddit import search_reddit
+from weles.utils.errors import RedditUnavailableError
+
+_BASE = "https://www.reddit.com"
+
+
+def _post(title: str = "Test Post", score: int = 100, post_id: str = "abc1") -> dict:
+    return {
+        "kind": "t3",
+        "data": {
+            "title": title,
+            "url": f"{_BASE}/r/BuyItForLife/comments/{post_id}/test/",
+            "score": score,
+            "created_utc": 1700000000.0,
+            "subreddit": "BuyItForLife",
+            "selftext": "Some body text here",
+            "id": post_id,
+            "permalink": f"/r/BuyItForLife/comments/{post_id}/test/",
+        },
+    }
+
+
+def _listing(*posts: dict) -> dict:
+    return {"kind": "Listing", "data": {"children": list(posts)}}
+
+
+def _comments(*bodies: tuple[str, int]) -> list:
+    children = [{"kind": "t1", "data": {"body": b, "score": s}} for b, s in bodies]
+    return [
+        {"kind": "Listing", "data": {"children": []}},
+        {"kind": "Listing", "data": {"children": children}},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_successful_response_returns_three_posts(httpx_mock: HTTPXMock, mocker) -> None:
+    mocker.patch("weles.tools.reddit.asyncio.sleep")
+    httpx_mock.add_response(
+        json=_listing(_post("P1", 100, "id1"), _post("P2", 50, "id2"), _post("P3", 10, "id3"))
+    )
+    httpx_mock.add_response(json=_comments(("Great", 42)))
+    httpx_mock.add_response(json=_comments(("Good", 20)))
+    httpx_mock.add_response(json=_comments(("OK", 5)))
+
+    posts = await search_reddit("test")
+
+    assert len(posts) == 3
+    assert posts[0]["title"] == "P1"
+    assert posts[0]["score"] == 100
+    assert "subreddit" in posts[0]
+    assert "selftext_preview" in posts[0]
+    assert isinstance(posts[0]["top_comments"], list)
+
+
+@pytest.mark.asyncio
+async def test_post_with_low_score_excluded(httpx_mock: HTTPXMock, mocker) -> None:
+    mocker.patch("weles.tools.reddit.asyncio.sleep")
+    low = _post("Low", score=3, post_id="low1")
+    high = _post("High", score=100, post_id="hi1")
+    httpx_mock.add_response(json=_listing(low, high))
+    httpx_mock.add_response(json=_comments(("Nice", 10)))
+
+    posts = await search_reddit("test")
+
+    assert len(posts) == 1
+    assert posts[0]["title"] == "High"
+
+
+@pytest.mark.asyncio
+async def test_429_triggers_retry_succeeds_on_second(httpx_mock: HTTPXMock, mocker) -> None:
+    mocker.patch("weles.tools.reddit.asyncio.sleep")
+    httpx_mock.add_response(status_code=429, headers={"Retry-After": "1"})
+    httpx_mock.add_response(json=_listing(_post()))
+    httpx_mock.add_response(json=_comments())
+
+    posts = await search_reddit("test")
+
+    assert len(posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_three_consecutive_failures_raise_reddit_unavailable(
+    httpx_mock: HTTPXMock, mocker
+) -> None:
+    mocker.patch("weles.tools.reddit.asyncio.sleep")
+    httpx_mock.add_response(status_code=500)
+    httpx_mock.add_response(status_code=500)
+    httpx_mock.add_response(status_code=500)
+
+    with pytest.raises(RedditUnavailableError):
+        await search_reddit("test")
+
+
+@pytest.mark.asyncio
+async def test_user_agent_header_present(httpx_mock: HTTPXMock, mocker) -> None:
+    mocker.patch("weles.tools.reddit.asyncio.sleep")
+    httpx_mock.add_response(json=_listing())
+
+    await search_reddit("test")
+
+    request = httpx_mock.get_requests()[0]
+    assert request.headers["User-Agent"] == "Weles/0.1"
+
+
+@pytest.mark.asyncio
+async def test_raw_json_param_present(httpx_mock: HTTPXMock, mocker) -> None:
+    mocker.patch("weles.tools.reddit.asyncio.sleep")
+    httpx_mock.add_response(json=_listing())
+
+    await search_reddit("test")
+
+    request = httpx_mock.get_requests()[0]
+    assert "raw_json=1" in str(request.url)
+
+
+@pytest.mark.asyncio
+async def test_deduplication_across_subreddits(httpx_mock: HTTPXMock, mocker) -> None:
+    mocker.patch("weles.tools.reddit.asyncio.sleep")
+    same_post = _post("Shared Post", score=100, post_id="shared1")
+    httpx_mock.add_response(json=_listing(same_post))  # sub1
+    httpx_mock.add_response(json=_listing(same_post))  # sub2
+    httpx_mock.add_response(json=_comments(("Top comment", 5)))  # comments for the one post
+
+    posts = await search_reddit("test", subreddits=["sub1", "sub2"])
+
+    assert len(posts) == 1

--- a/tests/unit/test_tool_limit.py
+++ b/tests/unit/test_tool_limit.py
@@ -1,0 +1,15 @@
+import pytest
+
+from weles.agent.dispatch import ToolRegistry
+from weles.utils.errors import MaxToolCallsError
+
+
+def test_7th_dispatch_raises_max_tool_calls_error() -> None:
+    registry = ToolRegistry(max_calls=6)
+    registry.register("t", lambda _: "ok", {"type": "object", "properties": {}})
+
+    for _ in range(6):
+        registry.dispatch("t", {})
+
+    with pytest.raises(MaxToolCallsError):
+        registry.dispatch("t", {})


### PR DESCRIPTION
## Issue

Closes #14

## What this PR does

Adds `search_reddit` Claude tool backed by Reddit's public JSON API with rate limiting, 429 backoff, retry logic, and per-subreddit scoping.

## Acceptance criteria

- [x] `search_reddit` tool registered in `ToolRegistry` on every request
- [x] Searches Reddit via public JSON API — no credentials, `raw_json=1`, `User-Agent: Weles/0.1`
- [x] Supports optional `subreddits` list for scoped search with URL-based deduplication
- [x] Posts with score < 5 excluded; results sorted by score descending
- [x] Top 3 comments fetched per post
- [x] Rate limiting: `asyncio.Semaphore(1)` + 1s sleep after every request
- [x] 429 backoff using `Retry-After` header; 3 retries before `RedditUnavailableError`
- [x] `max_tool_calls_per_turn` read from settings (default 6); 7th call raises `MaxToolCallsError` → `ToolErrorEvent`
- [x] `ToolRegistry` updated with `max_calls` counter and `adispatch()` for async handlers
- [x] Agentic tool-use loop in `stream_response` continues until `end_turn`

## Tests

- [x] All tests specified in the issue are present (`test_reddit.py`, `test_tool_limit.py`)
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (no endpoint changes)
- [x] `docs/architecture.md` updated (tool-use loop, ToolRegistry async, Reddit tool)

## Notes

`ToolRegistry.dispatch()` remains sync for backward compatibility; `adispatch()` is the new async-aware entry point used by `stream_response`. It uses `inspect.isawaitable()` to detect and await coroutine handlers while accepting plain sync handlers unchanged.