### PR TITLE
feat: #16 Web search fallback tool

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,14 +80,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `max_tool_calls_per_turn` enforced in `ToolRegistry`: reads from settings (default 6); 7th call in a turn raises `MaxToolCallsError` → `ToolErrorEvent` (#14)
 - LangSmith tracing: Anthropic client wrapped with `wrap_anthropic`; `stream_response` decorated with `@traceable(run_type="chain")`; `ToolRegistry.adispatch` decorated with `@traceable(run_type="tool")`
 - `LANGSMITH_ENDPOINT`, `LANGSMITH_API_KEY`, `LANGSMITH_PROJECT`, `LANGSMITH_TRACING` added to `.env.example`; tracing is a no-op when `LANGSMITH_TRACING` is absent or false
+- `search_web` Claude tool: searches the open web via Tavily API; returns `WebResult` objects classified by domain as `community`, `commercial`, or `unknown`; results sorted community-first (#16)
+- Domain lists (`community_domains.txt`, `commercial_domains.txt`) preloaded at startup via `resource_path`; cached in module-level sets (#16)
+- `search_web` registered in `ToolRegistry` only when `TAVILY_API_KEY` is set; absent key → tool not registered, no crash (#16)
 
 ### Fixed
 - Reddit requests returning 403: switched `User-Agent` from `Weles/0.1` to a Chrome browser string; added `Accept` and `Accept-Language` headers
 - `GeneratorExit` error logged in LangSmith traces: removed early `break` on `DoneEvent` in the SSE router so `stream_response` exhausts naturally instead of being closed mid-flight
-
-- `search_web` Claude tool: searches the open web via Tavily API; returns `WebResult` objects classified by domain as `community`, `commercial`, or `unknown`; results sorted community-first (#16)
-- Domain classification loaded at startup from `blocklist/community_domains.txt` and `blocklist/commercial_domains.txt` via `resource_path`; cached in module-level sets (#16)
-- `search_web` registered in `ToolRegistry` only when `TAVILY_API_KEY` is set; absent key → tool not registered, no crash (#16)
 
 ### v0.4 — Domain Modules
 <!-- Issues #19–22 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reddit requests returning 403: switched `User-Agent` from `Weles/0.1` to a Chrome browser string; added `Accept` and `Accept-Language` headers
 - `GeneratorExit` error logged in LangSmith traces: removed early `break` on `DoneEvent` in the SSE router so `stream_response` exhausts naturally instead of being closed mid-flight
 
-<!-- Issues #15–18 -->
+- `search_web` Claude tool: searches the open web via Tavily API; returns `WebResult` objects classified by domain as `community`, `commercial`, or `unknown`; results sorted community-first (#16)
+- Domain classification loaded at startup from `blocklist/community_domains.txt` and `blocklist/commercial_domains.txt` via `resource_path`; cached in module-level sets (#16)
+- `search_web` registered in `ToolRegistry` only when `TAVILY_API_KEY` is set; absent key → tool not registered, no crash (#16)
 
 ### v0.4 — Domain Modules
 <!-- Issues #19–22 -->

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -29,6 +29,7 @@ from weles.db.settings_repo import get_setting
 from weles.tools.history_tools import ADD_TO_HISTORY_SCHEMA, add_to_history_handler
 from weles.tools.profile_tools import SAVE_PROFILE_FIELD_SCHEMA, save_profile_field_handler
 from weles.tools.reddit import SEARCH_REDDIT_SCHEMA, search_reddit_handler
+from weles.tools.web import SEARCH_WEB_SCHEMA, search_web_handler
 from weles.utils.errors import ConfigurationError
 
 _MODE_TO_DOMAIN = {
@@ -160,6 +161,12 @@ async def post_message(session_id: str, body: MessageBody, request: Request) -> 
             search_reddit_handler,
             SEARCH_REDDIT_SCHEMA,
         )
+        if request.app.state.web_search_available:
+            registry.register(
+                "search_web",
+                search_web_handler,
+                SEARCH_WEB_SCHEMA,
+            )
 
         try:
             client = get_client()

--- a/src/weles/api/startup.py
+++ b/src/weles/api/startup.py
@@ -74,6 +74,7 @@ async def startup(state: Any) -> None:
     from alembic.config import Config
 
     cfg = Config(str(resource_path("alembic.ini")))
+    cfg.set_main_option("script_location", str(resource_path("alembic")))
     command.upgrade(cfg, "head")
 
     # 5. Seed default settings if table is empty
@@ -83,7 +84,10 @@ async def startup(state: Any) -> None:
         conn.executemany("INSERT INTO settings (key, value) VALUES (?, ?)", _DEFAULT_SETTINGS)
         conn.commit()
 
-    # 6. Check TAVILY_API_KEY
+    # 6. Check TAVILY_API_KEY; preload domain sets regardless so missing files surface early
+    from weles.tools.web import preload_domain_sets
+
+    preload_domain_sets()
     if os.getenv("TAVILY_API_KEY"):
         state.web_search_available = True
     else:

--- a/src/weles/tools/web.py
+++ b/src/weles/tools/web.py
@@ -40,8 +40,14 @@ def _get_commercial_domains() -> set[str]:
     return _commercial_domains
 
 
-def _classify_domain(domain: str) -> str:
-    domain = domain.lower().removeprefix("www.")
+def preload_domain_sets() -> None:
+    """Eagerly load domain sets at startup so missing files surface immediately."""
+    _get_community_domains()
+    _get_commercial_domains()
+
+
+def _classify_domain(netloc: str) -> str:
+    domain = netloc.lower().removeprefix("www.")
     if domain in _get_community_domains():
         return "community"
     if domain in _get_commercial_domains():
@@ -79,8 +85,9 @@ async def search_web(query: str, limit: int = 8) -> list[WebResult]:
     results: list[WebResult] = []
     for item in data.get("results", []):
         url = item.get("url", "")
-        domain = urlparse(url).netloc.lower().removeprefix("www.")
-        source_type = _classify_domain(domain)
+        netloc = urlparse(url).netloc
+        domain = netloc.lower().removeprefix("www.")
+        source_type = _classify_domain(netloc)
         results.append(
             WebResult(
                 title=item.get("title", ""),
@@ -91,7 +98,7 @@ async def search_web(query: str, limit: int = 8) -> list[WebResult]:
             )
         )
 
-    results.sort(key=lambda r: _SORT_ORDER[r["source_type"]])
+    results.sort(key=lambda r: _SORT_ORDER.get(r["source_type"], 1))
     return results
 
 

--- a/src/weles/tools/web.py
+++ b/src/weles/tools/web.py
@@ -1,0 +1,122 @@
+import os
+from typing import Any, TypedDict
+from urllib.parse import urlparse
+
+import httpx
+
+from weles.agent.dispatch import ToolResult
+from weles.utils.paths import resource_path
+
+_TAVILY_URL = "https://api.tavily.com/search"
+
+_community_domains: set[str] | None = None
+_commercial_domains: set[str] | None = None
+
+
+def _load_domain_set(filename: str) -> set[str]:
+    path = resource_path(f"blocklist/{filename}")
+    domains: set[str] = set()
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                domains.add(line.lower())
+    except OSError:
+        pass
+    return domains
+
+
+def _get_community_domains() -> set[str]:
+    global _community_domains
+    if _community_domains is None:
+        _community_domains = _load_domain_set("community_domains.txt")
+    return _community_domains
+
+
+def _get_commercial_domains() -> set[str]:
+    global _commercial_domains
+    if _commercial_domains is None:
+        _commercial_domains = _load_domain_set("commercial_domains.txt")
+    return _commercial_domains
+
+
+def _classify_domain(domain: str) -> str:
+    domain = domain.lower().removeprefix("www.")
+    if domain in _get_community_domains():
+        return "community"
+    if domain in _get_commercial_domains():
+        return "commercial"
+    return "unknown"
+
+
+_SORT_ORDER = {"community": 0, "unknown": 1, "commercial": 2}
+
+
+class WebResult(TypedDict):
+    title: str
+    url: str
+    snippet: str
+    domain: str
+    source_type: str
+
+
+async def search_web(query: str, limit: int = 8) -> list[WebResult]:
+    api_key = os.getenv("TAVILY_API_KEY", "")
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            _TAVILY_URL,
+            json={
+                "api_key": api_key,
+                "query": query,
+                "search_depth": "advanced",
+                "max_results": limit,
+                "include_raw_content": False,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    results: list[WebResult] = []
+    for item in data.get("results", []):
+        url = item.get("url", "")
+        domain = urlparse(url).netloc.lower().removeprefix("www.")
+        source_type = _classify_domain(domain)
+        results.append(
+            WebResult(
+                title=item.get("title", ""),
+                url=url,
+                snippet=item.get("content", ""),
+                domain=domain,
+                source_type=source_type,
+            )
+        )
+
+    results.sort(key=lambda r: _SORT_ORDER[r["source_type"]])
+    return results
+
+
+SEARCH_WEB_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string", "description": "Search query."},
+        "limit": {
+            "type": "integer",
+            "default": 8,
+            "description": "Max results to return (default 8).",
+        },
+    },
+    "required": ["query"],
+}
+
+
+async def search_web_handler(tool_input: dict[str, Any]) -> ToolResult:
+    results = await search_web(
+        query=tool_input["query"],
+        limit=tool_input.get("limit", 8),
+    )
+    if not results:
+        return ToolResult(summary="No results found.", data=[])
+    return ToolResult(
+        summary=f"Found {len(results)} results",
+        data=results,
+    )

--- a/tests/unit/test_tool_registration.py
+++ b/tests/unit/test_tool_registration.py
@@ -1,0 +1,21 @@
+from weles.agent.dispatch import ToolRegistry
+from weles.tools.web import SEARCH_WEB_SCHEMA, search_web_handler
+
+
+def _make_registry(web_search_available: bool) -> ToolRegistry:
+    registry = ToolRegistry(max_calls=6)
+    if web_search_available:
+        registry.register("search_web", search_web_handler, SEARCH_WEB_SCHEMA)
+    return registry
+
+
+def test_search_web_excluded_when_web_search_unavailable() -> None:
+    registry = _make_registry(web_search_available=False)
+    names = [schema["name"] for schema in registry.get_tool_schemas()]
+    assert "search_web" not in names
+
+
+def test_search_web_included_when_web_search_available() -> None:
+    registry = _make_registry(web_search_available=True)
+    names = [schema["name"] for schema in registry.get_tool_schemas()]
+    assert "search_web" in names

--- a/tests/unit/test_web_search.py
+++ b/tests/unit/test_web_search.py
@@ -35,7 +35,7 @@ async def test_successful_response_parsed_into_web_results(httpx_mock: HTTPXMock
     results = await search_web("best headphones")
 
     assert len(results) == 2
-    assert results[0]["title"] in ("Post One", "Post Two")
+    assert {r["title"] for r in results} == {"Post One", "Post Two"}
     for r in results:
         assert "title" in r
         assert "url" in r

--- a/tests/unit/test_web_search.py
+++ b/tests/unit/test_web_search.py
@@ -1,0 +1,130 @@
+import pytest
+from pytest_httpx import HTTPXMock
+
+import weles.tools.web as web_module
+from weles.tools.web import search_web
+
+_TAVILY_URL = "https://api.tavily.com/search"
+
+
+def _tavily_response(*results: dict) -> dict:
+    return {"results": list(results), "answer": None}
+
+
+def _result(title: str = "Title", url: str = "https://example.com/page") -> dict:
+    return {"title": title, "url": url, "content": "Some snippet"}
+
+
+@pytest.fixture(autouse=True)
+def reset_domain_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(web_module, "_community_domains", None)
+    monkeypatch.setattr(web_module, "_commercial_domains", None)
+
+
+@pytest.mark.asyncio
+async def test_successful_response_parsed_into_web_results(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url=_TAVILY_URL,
+        method="POST",
+        json=_tavily_response(
+            _result("Post One", "https://reddit.com/r/gadgets/1"),
+            _result("Post Two", "https://amazon.com/product/2"),
+        ),
+    )
+
+    results = await search_web("best headphones")
+
+    assert len(results) == 2
+    assert results[0]["title"] in ("Post One", "Post Two")
+    for r in results:
+        assert "title" in r
+        assert "url" in r
+        assert "snippet" in r
+        assert "domain" in r
+        assert "source_type" in r
+
+
+@pytest.mark.asyncio
+async def test_community_domain_gets_community_source_type(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(web_module, "_community_domains", {"reddit.com"})
+    monkeypatch.setattr(web_module, "_commercial_domains", set())
+    httpx_mock.add_response(
+        url=_TAVILY_URL,
+        method="POST",
+        json=_tavily_response(_result("Thread", "https://reddit.com/r/gadgets/abc")),
+    )
+
+    results = await search_web("query")
+
+    assert results[0]["source_type"] == "community"
+
+
+@pytest.mark.asyncio
+async def test_commercial_domain_gets_commercial_source_type(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(web_module, "_community_domains", set())
+    monkeypatch.setattr(web_module, "_commercial_domains", {"amazon.com"})
+    httpx_mock.add_response(
+        url=_TAVILY_URL,
+        method="POST",
+        json=_tavily_response(_result("Product", "https://amazon.com/product/123")),
+    )
+
+    results = await search_web("query")
+
+    assert results[0]["source_type"] == "commercial"
+
+
+@pytest.mark.asyncio
+async def test_unknown_domain_gets_unknown_source_type(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(web_module, "_community_domains", set())
+    monkeypatch.setattr(web_module, "_commercial_domains", set())
+    httpx_mock.add_response(
+        url=_TAVILY_URL,
+        method="POST",
+        json=_tavily_response(_result("Page", "https://somesite.example/page")),
+    )
+
+    results = await search_web("query")
+
+    assert results[0]["source_type"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_community_results_sorted_before_commercial(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(web_module, "_community_domains", {"reddit.com"})
+    monkeypatch.setattr(web_module, "_commercial_domains", {"amazon.com"})
+    httpx_mock.add_response(
+        url=_TAVILY_URL,
+        method="POST",
+        json=_tavily_response(
+            _result("Commercial First", "https://amazon.com/product/1"),
+            _result("Community Second", "https://reddit.com/r/gadgets/2"),
+        ),
+    )
+
+    results = await search_web("query")
+
+    assert results[0]["source_type"] == "community"
+    assert results[1]["source_type"] == "commercial"
+
+
+@pytest.mark.asyncio
+async def test_tavily_500_raises_exception(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url=_TAVILY_URL,
+        method="POST",
+        status_code=500,
+    )
+
+    import httpx
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await search_web("query")


### PR DESCRIPTION
## Issue

Closes #16

## What this PR does

Adds a `search_web` Claude tool that queries the Tavily API and classifies results by domain as community, commercial, or unknown; registered only when `TAVILY_API_KEY` is set.

## Acceptance criteria

- [x] Claude tool `search_web(query, limit=8)` returns list of `WebResult` objects
- [x] `WebResult`: `{title, url, snippet, domain, source_type: "community"|"commercial"|"unknown"}`
- [x] Domain classification against `community_domains.txt` / `commercial_domains.txt` loaded via `resource_path`
- [x] Results sorted community-first, commercial-last before return
- [x] Tavily request uses `search_depth: "advanced"`, `max_results: limit`, `include_raw_content: false`; `answer` field ignored
- [x] On Tavily error: exception propagates → `ToolErrorEvent` emitted by stream layer
- [x] Tool registered conditionally in `messages.py` when `app.state.web_search_available` is True
- [x] Domain sets cached at module level

## Tests

- [x] All tests specified in the issue are present
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (if endpoints changed) — no endpoint changes
- [ ] `docs/architecture.md` updated (if patterns or module boundaries changed) — no pattern changes

## Notes

The tool registration sits in `messages.py` (inside the request handler) rather than in `startup.py` because `ToolRegistry` is per-request. The `web_search_available` flag is read from `app.state` which is set during startup.

`search_web` raises `httpx.HTTPStatusError` on non-2xx Tavily responses; the stream layer in `stream.py` catches this and emits `ToolErrorEvent`, consistent with A12.