### PR TITLE
feat: #17 source credibility scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `search_web` Claude tool: searches the open web via Tavily API; returns `WebResult` objects classified by domain as `community`, `commercial`, or `unknown`; results sorted community-first (#16)
 - Domain lists (`community_domains.txt`, `commercial_domains.txt`) preloaded at startup via `resource_path`; cached in module-level sets (#16)
 - `search_web` registered in `ToolRegistry` only when `TAVILY_API_KEY` is set; absent key → tool not registered, no crash (#16)
+- `score_result(RedditPost | WebResult) -> CredibilityLabel` in `research/credibility.py`; labels `high`, `medium`, `low`, `flagged` (#17)
+- Reddit scoring: score thresholds (low < 20, medium 20–99, high ≥ 100) with one-tier promotion for ownership-language and "switched from" patterns (#17)
+- Web scoring: community domains → `high`, commercial → `low`, unknown → `medium`; affiliate URL patterns (`?ref=`, `/go/`, etc.) → `flagged` regardless of source type (#17)
+- `score_results()` batch function: appends `credibility` to each result; sets `batch_flag="coordinated_positivity"` when ≥ 3 low/flagged results share a 4-word n-gram (#17)
+- Research prompt updated: Claude instructed to discount `low`/`flagged` results and surface astroturfing warning when `coordinated_positivity` is set (#17)
 
 ### Fixed
 - Reddit requests returning 403: switched `User-Agent` from `Weles/0.1` to a Chrome browser string; added `Accept` and `Accept-Language` headers

--- a/src/weles/prompts/research.md
+++ b/src/weles/prompts/research.md
@@ -1,3 +1,9 @@
 # Research Guidelines
 
 When calling `search_reddit`, pass the most specific subcategory that matches the user's query using the `subcategory` parameter — the server resolves it to the right subreddits. Available subcategories for the current mode are listed in your system context. If none fits, omit `subcategory` and the general list for this mode is used. If the user explicitly names a subreddit, pass it via `subreddits` instead.
+
+When interpreting search results, each result carries a `credibility` field (`high`, `medium`, `low`, or `flagged`).
+
+- Heavily discount `low` and `flagged` results. Treat them as weak signal only — do not base recommendations primarily on them.
+- If the result set includes `"batch_flag": "coordinated_positivity"`, mention the possibility of astroturfing or coordinated promotion to the user.
+- Prefer `high` credibility results (community sources, high-score Reddit posts with ownership history) when drawing conclusions.

--- a/src/weles/research/credibility.py
+++ b/src/weles/research/credibility.py
@@ -6,7 +6,9 @@ from weles.tools.web import WebResult
 
 CredibilityLabel = Literal["high", "medium", "low", "flagged"]
 
-_OWNERSHIP_RE = re.compile(r"\b(owned?|had|using|used)\b.{0,40}\b(\d+)\s*(year|month)s?\b")
+_OWNERSHIP_RE = re.compile(
+    r"\b(owned?|had|using|used)\b.{0,40}\b(\d+)\s*(year|month)s?\b", re.DOTALL
+)
 _SWITCHED_RE = re.compile(r"\bswitched?\s+(from|away\s+from)\b")
 _AFFILIATE_RE = re.compile(r"[?&](ref|aff|tag)=|/(go|out|recommends)/")
 

--- a/src/weles/research/credibility.py
+++ b/src/weles/research/credibility.py
@@ -1,0 +1,96 @@
+import re
+from typing import Any, Literal, cast
+
+from weles.tools.reddit import RedditPost
+from weles.tools.web import WebResult
+
+CredibilityLabel = Literal["high", "medium", "low", "flagged"]
+
+_OWNERSHIP_RE = re.compile(r"\b(owned?|had|using|used)\b.{0,40}\b(\d+)\s*(year|month)s?\b")
+_SWITCHED_RE = re.compile(r"\bswitched?\s+(from|away\s+from)\b")
+_AFFILIATE_RE = re.compile(r"[?&](ref|aff|tag)=|/(go|out|recommends)/")
+
+_TIERS: list[CredibilityLabel] = ["low", "medium", "high"]
+
+
+def _promote(label: CredibilityLabel) -> CredibilityLabel:
+    if label == "flagged":
+        return "flagged"
+    idx = _TIERS.index(label)
+    return _TIERS[min(idx + 1, len(_TIERS) - 1)]
+
+
+def _score_reddit(result: RedditPost) -> CredibilityLabel:
+    score = result["score"]
+    if score >= 100:
+        label: CredibilityLabel = "high"
+    elif score >= 20:
+        label = "medium"
+    else:
+        label = "low"
+
+    body = result["selftext_preview"] or ""
+    if _OWNERSHIP_RE.search(body):
+        label = _promote(label)
+    if _SWITCHED_RE.search(body):
+        label = _promote(label)
+
+    return label
+
+
+def _score_web(result: WebResult) -> CredibilityLabel:
+    if _AFFILIATE_RE.search(result["url"]):
+        return "flagged"
+    source_type = result["source_type"]
+    if source_type == "community":
+        return "high"
+    if source_type == "commercial":
+        return "low"
+    return "medium"
+
+
+def score_result(result: RedditPost | WebResult) -> CredibilityLabel:
+    if "score" in result:
+        return _score_reddit(cast(RedditPost, result))
+    return _score_web(result)
+
+
+def _ngrams(text: str, n: int) -> set[tuple[str, ...]]:
+    words = text.lower().split()
+    if len(words) < n:
+        return set()
+    return {tuple(words[i : i + n]) for i in range(len(words) - n + 1)}
+
+
+def score_results(
+    results: list[RedditPost | WebResult],
+) -> dict[str, Any]:
+    """Score all results, appending `credibility` to each. Returns dict with `results`
+    and optional top-level `batch_flag` when coordinated positivity is detected."""
+    labels = [score_result(r) for r in results]
+    scored = [{**r, "credibility": label} for r, label in zip(results, labels, strict=True)]
+
+    low_flagged_texts: list[str] = []
+    for result, label in zip(results, labels, strict=True):
+        if label not in ("low", "flagged"):
+            continue
+        if "score" in result:
+            text = cast(RedditPost, result)["selftext_preview"] or ""
+        else:
+            text = result["snippet"] or ""
+        low_flagged_texts.append(text)
+
+    batch_flag: str | None = None
+    if len(low_flagged_texts) >= 3:
+        ngram_sets = [_ngrams(t, 4) for t in low_flagged_texts]
+        counts: dict[tuple[str, ...], int] = {}
+        for ns in ngram_sets:
+            for gram in ns:
+                counts[gram] = counts.get(gram, 0) + 1
+        if any(count >= 3 for count in counts.values()):
+            batch_flag = "coordinated_positivity"
+
+    out: dict[str, Any] = {"results": scored}
+    if batch_flag:
+        out["batch_flag"] = batch_flag
+    return out

--- a/tests/unit/test_credibility.py
+++ b/tests/unit/test_credibility.py
@@ -1,0 +1,66 @@
+from weles.research.credibility import score_result, score_results
+from weles.tools.reddit import RedditPost
+from weles.tools.web import WebResult
+
+
+def _reddit(score: int, body: str = "") -> RedditPost:
+    return RedditPost(
+        title="test",
+        url="https://reddit.com/r/test/comments/abc",
+        score=score,
+        created_utc=0.0,
+        subreddit="test",
+        selftext_preview=body,
+        top_comments=[],
+    )
+
+
+def _web(source_type: str = "unknown", url: str = "https://example.com") -> WebResult:
+    return WebResult(
+        title="test",
+        url=url,
+        snippet="test snippet about this product",
+        domain="example.com",
+        source_type=source_type,
+    )
+
+
+def test_reddit_score_50_medium():
+    assert score_result(_reddit(50)) == "medium"
+
+
+def test_reddit_score_150_high():
+    assert score_result(_reddit(150)) == "high"
+
+
+def test_reddit_score_50_ownership_promotes_to_high():
+    body = "I have owned this for 3 years and it still works great"
+    assert score_result(_reddit(50, body)) == "high"
+
+
+def test_web_community_high():
+    assert score_result(_web("community")) == "high"
+
+
+def test_web_affiliate_url_flagged():
+    assert score_result(_web(url="https://example.com/product?ref=affiliate123")) == "flagged"
+
+
+def test_batch_flag_three_low_with_shared_ngram():
+    body = "this is a great product that everyone should buy today"
+    results = [_reddit(10, body), _reddit(15, body), _reddit(8, body)]
+    out = score_results(results)
+    assert out.get("batch_flag") == "coordinated_positivity"
+
+
+def test_batch_flag_two_low_no_flag():
+    body = "this is a great product that everyone should buy today"
+    results = [_reddit(10, body), _reddit(15, body)]
+    out = score_results(results)
+    assert "batch_flag" not in out
+
+
+def test_promotion_capped_at_high():
+    # score ≥ 100 → high; ownership + switched both try to promote → stays high
+    body = "I have owned this for 5 years and switched from the competitor"
+    assert score_result(_reddit(150, body)) == "high"


### PR DESCRIPTION
## Issue

Closes #17

## What this PR does

Adds `score_result()` and `score_results()` in `research/credibility.py` to tag every search result with a credibility label before Claude sees it.

## Acceptance criteria

- [x] `score_result(result: RedditPost | WebResult) -> CredibilityLabel` in `src/weles/research/credibility.py`
- [x] `CredibilityLabel`: `"high" | "medium" | "low" | "flagged"`
- [x] Reddit rules: score thresholds (low <20, medium 20–99, high ≥100) with one-tier promotion for ownership-language and "switched from" regex patterns; promotion capped at `high`
- [x] Web rules: `community` → `high`, `commercial` → `low`, `unknown` → `medium`; affiliate URL patterns (`?ref=`, `?aff=`, `?tag=`, `/go/`, `/out/`, `/recommends/`) → `flagged` regardless of source type
- [x] `score_results()` batch function: appends `credibility` to each result; sets `batch_flag="coordinated_positivity"` when ≥3 low/flagged results share a 4-word n-gram
- [x] Research prompt instructs Claude to discount `low`/`flagged` and mention astroturfing when `coordinated_positivity` is set

## Tests

- [x] All tests specified in the issue are present (`tests/unit/test_credibility.py`, 8 tests)
- [x] `make lint` passes
- [x] `make test` passes (88 passed)
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (if endpoints changed) — no endpoints changed
- [ ] `docs/architecture.md` updated — `research/credibility.py` row already present in module map