### PR TITLE
feat: #18 research synthesis, error resilience, and tool call cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Web scoring: community domains → `high`, commercial → `low`, unknown → `medium`; affiliate URL patterns (`?ref=`, `/go/`, etc.) → `flagged` regardless of source type (#17)
 - `score_results()` batch function: appends `credibility` to each result; sets `batch_flag="coordinated_positivity"` when ≥ 3 low/flagged results share a 4-word n-gram (#17)
 - Research prompt updated: Claude instructed to discount `low`/`flagged` results and surface astroturfing warning when `coordinated_positivity` is set (#17)
+- Research synthesis guidelines in `research.md`: signal strength labels (`[strong consensus]` / `[divided community]` / `[thin data]`), dissenting views, age/discontinuation flags, no manufacturer language, reasoning over conclusions (#18)
+- Research guidelines injected into user turn as a text block on first `search_reddit` or `search_web` call; injected once per stream (#18)
+- Tool failure notice sent to Claude after each tool batch: lists failed tool names; Claude instructed to continue and state which sources were unavailable (#18)
+- `ToolErrorEvent(tool="max_tool_calls", error="Research limit reached")` emitted when limit exceeded; sentinel `"Research limit reached. Synthesise with what you have."` sent to Claude (#18)
+- `scripts/eval_research.py`: runs 5 representative queries against live Claude for manual synthesis quality review; not a CI test (#18)
 
 ### Fixed
 - Reddit requests returning 403: switched `User-Agent` from `Weles/0.1` to a Chrome browser string; added `Accept` and `Accept-Language` headers

--- a/scripts/eval_research.py
+++ b/scripts/eval_research.py
@@ -1,1 +1,81 @@
-# Research quality evaluation script — implemented in later issues
+#!/usr/bin/env python3
+"""
+Manual eval script for research synthesis quality.
+Runs 5 representative queries against live Claude and prints results.
+
+Requires: ANTHROPIC_API_KEY set. TAVILY_API_KEY optional (enables web search).
+Not a CI test — run manually for qualitative review.
+
+Usage:
+    uv run python scripts/eval_research.py
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# Ensure src/ is on the path when run from the repo root
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+QUERIES = [
+    ("shopping", "What's the best budget mechanical keyboard for daily use?"),
+    ("shopping", "Recommend a durable cast iron pan for a beginner cook"),
+    ("fitness", "What running shoes do long-distance runners recommend?"),
+    ("diet", "What do people say about intermittent fasting for weight loss?"),
+    ("lifestyle", "What air purifier is most recommended by allergy sufferers?"),
+]
+
+
+async def run_query(mode: str, query: str) -> None:
+    from weles.agent.client import get_client
+    from weles.agent.dispatch import ToolRegistry
+    from weles.agent.prompts import build_system_prompt
+    from weles.agent.stream import (
+        DoneEvent,
+        TextDeltaEvent,
+        ToolEndEvent,
+        ToolErrorEvent,
+        ToolStartEvent,
+        stream_response,
+    )
+    from weles.tools.reddit import SEARCH_REDDIT_SCHEMA, search_reddit_handler
+
+    client = get_client()
+    system = build_system_prompt(mode)
+    registry = ToolRegistry(max_calls=6)
+    registry.register("search_reddit", search_reddit_handler, SEARCH_REDDIT_SCHEMA)
+
+    if os.getenv("TAVILY_API_KEY"):
+        from weles.tools.web import SEARCH_WEB_SCHEMA, search_web_handler
+
+        registry.register("search_web", search_web_handler, SEARCH_WEB_SCHEMA)
+
+    messages = [{"role": "user", "content": query}]
+
+    print(f"\n{'=' * 60}")
+    print(f"Mode: {mode}  |  Query: {query}")
+    print("=" * 60)
+
+    async for event in stream_response(
+        client, messages, registry.get_tool_schemas(), system, registry
+    ):
+        if isinstance(event, TextDeltaEvent):
+            print(event.text, end="", flush=True)
+        elif isinstance(event, ToolStartEvent):
+            print(f"\n[TOOL: {event.description}]", flush=True)
+        elif isinstance(event, ToolEndEvent):
+            print(f"[TOOL DONE: {event.result_summary}]", flush=True)
+        elif isinstance(event, ToolErrorEvent):
+            print(f"[TOOL ERROR: {event.tool} — {event.error}]", flush=True)
+        elif isinstance(event, DoneEvent):
+            print("\n[DONE]", flush=True)
+
+
+async def main() -> None:
+    for mode, query in QUERIES:
+        await run_query(mode, query)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/weles/agent/stream.py
+++ b/src/weles/agent/stream.py
@@ -12,6 +12,9 @@ from anthropic.types import (
 )
 from langsmith import traceable
 
+from weles.utils.errors import MaxToolCallsError
+from weles.utils.paths import resource_path
+
 if TYPE_CHECKING:
     from weles.agent.dispatch import ToolRegistry
 
@@ -46,6 +49,9 @@ class DoneEvent:
 
 AgentEvent = TextDeltaEvent | ToolStartEvent | ToolEndEvent | ToolErrorEvent | DoneEvent
 
+_RESEARCH_TOOLS = {"search_reddit", "search_web"}
+_RESEARCH_PROMPT_PATH = "src/weles/prompts/research.md"
+
 
 def _build_description(tool_name: str, tool_input: dict[str, Any]) -> str:
     if tool_name == "search_reddit":
@@ -67,6 +73,16 @@ def _build_description(tool_name: str, tool_input: dict[str, Any]) -> str:
     return f"Running {tool_name}…"
 
 
+def _build_failure_message(failed_tools: list[str]) -> str | None:
+    if not failed_tools:
+        return None
+    tools_str = ", ".join(failed_tools)
+    return (
+        f"The following tools failed: {tools_str}. "
+        "Continue with available data. State in your response which sources were unavailable."
+    )
+
+
 @traceable(run_type="chain", name="agent_loop")
 async def stream_response(
     client: anthropic.Anthropic,
@@ -79,6 +95,7 @@ async def stream_response(
     max_tokens = int(os.environ.get("WELES_MAX_TOKENS", "4096"))
 
     current_messages = list(messages)
+    research_guidance_injected = False
 
     while True:
         kwargs: dict[str, Any] = {
@@ -105,6 +122,7 @@ async def stream_response(
 
         tool_uses = [b for b in final_message.content if isinstance(b, ToolUseBlock)]
         tool_results = []
+        failed_tools: list[str] = []
 
         for tool_use in tool_uses:
             description = _build_description(tool_use.name, tool_use.input)
@@ -113,6 +131,9 @@ async def stream_response(
                 result = await registry.adispatch(tool_use.name, tool_use.input)
                 yield ToolEndEvent(tool=tool_use.name, result_summary=result.summary)
                 result_content = str(result.data)
+            except MaxToolCallsError:
+                yield ToolErrorEvent(tool="max_tool_calls", error="Research limit reached")
+                result_content = "Research limit reached. Synthesise with what you have."
             except Exception as exc:
                 error_msg = str(exc)
                 yield ToolErrorEvent(tool=tool_use.name, error=error_msg)
@@ -120,6 +141,7 @@ async def stream_response(
                     f"Tool {tool_use.name} failed: {error_msg}. "
                     "Continue with available data; note the limitation in your response."
                 )
+                failed_tools.append(tool_use.name)
 
             tool_results.append(
                 {
@@ -143,7 +165,21 @@ async def stream_response(
                     }
                 )
 
+        # Build user content: optional research guidance + optional failure notice + tool results
+        user_content: list[dict[str, Any]] = []
+
+        if not research_guidance_injected and any(t.name in _RESEARCH_TOOLS for t in tool_uses):
+            guidance = resource_path(_RESEARCH_PROMPT_PATH).read_text(encoding="utf-8")
+            user_content.append({"type": "text", "text": guidance})
+            research_guidance_injected = True
+
+        failure_msg = _build_failure_message(failed_tools)
+        if failure_msg:
+            user_content.append({"type": "text", "text": failure_msg})
+
+        user_content.extend(tool_results)
+
         current_messages = current_messages + [
             {"role": "assistant", "content": assistant_content},
-            {"role": "user", "content": tool_results},
+            {"role": "user", "content": user_content},
         ]

--- a/src/weles/prompts/research.md
+++ b/src/weles/prompts/research.md
@@ -7,3 +7,15 @@ When interpreting search results, each result carries a `credibility` field (`hi
 - Heavily discount `low` and `flagged` results. Treat them as weak signal only — do not base recommendations primarily on them.
 - If the result set includes `"batch_flag": "coordinated_positivity"`, mention the possibility of astroturfing or coordinated promotion to the user.
 - Prefer `high` credibility results (community sources, high-score Reddit posts with ownership history) when drawing conclusions.
+
+## Synthesis guidelines
+
+[Research guidance]
+- Open with signal strength: [strong consensus] / [divided community] / [thin data]
+- Use [thin data] when fewer than 3 relevant posts found across all searches, or all searches failed
+- Surface dissenting views when a vocal minority exists
+- Flag data older than 3 years: "Note: most discussion on this dates to [year]."
+- Flag discontinued products explicitly
+- Never use manufacturer language, spec-sheet comparisons, or affiliate superlatives
+- Show reasoning: not "buy X" but "Long-term owners prefer X because Y. Common failure point: Z."
+- When communities disagree, present both sides labelled by source — do not pick a side unless the user's profile provides clear directional preference

--- a/tests/unit/test_synthesis.py
+++ b/tests/unit/test_synthesis.py
@@ -1,0 +1,13 @@
+from weles.agent.stream import _build_failure_message
+
+
+def test_single_failed_tool_produces_failure_message():
+    msg = _build_failure_message(["search_reddit"])
+    assert msg is not None
+    assert "search_reddit" in msg
+    assert "Continue with available data" in msg
+    assert "which sources were unavailable" in msg
+
+
+def test_empty_failed_tools_produces_no_message():
+    assert _build_failure_message([]) is None

--- a/tests/unit/test_tool_limit.py
+++ b/tests/unit/test_tool_limit.py
@@ -78,3 +78,12 @@ async def test_exceeding_limit_emits_max_tool_calls_event_with_correct_fields() 
     max_calls_errors = [e for e in error_events if e.tool == "max_tool_calls"]
     assert len(max_calls_errors) >= 1
     assert max_calls_errors[0].error == "Research limit reached"
+
+    # Verify sentinel string was passed as tool result content to Claude
+    second_call_kwargs = mock_client.messages.stream.call_args_list[1][1]
+    last_user_content = second_call_kwargs["messages"][-1]["content"]
+    sentinel = "Research limit reached. Synthesise with what you have."
+    assert any(
+        item.get("type") == "tool_result" and item.get("content") == sentinel
+        for item in last_user_content
+    )

--- a/tests/unit/test_tool_limit.py
+++ b/tests/unit/test_tool_limit.py
@@ -1,6 +1,10 @@
+from unittest.mock import MagicMock
+
 import pytest
+from anthropic.types import RawMessageStopEvent, ToolUseBlock
 
 from weles.agent.dispatch import ToolRegistry
+from weles.agent.stream import ToolErrorEvent, stream_response
 from weles.utils.errors import MaxToolCallsError
 
 
@@ -13,3 +17,64 @@ def test_7th_dispatch_raises_max_tool_calls_error() -> None:
 
     with pytest.raises(MaxToolCallsError):
         registry.dispatch("t", {})
+
+
+def test_call_count_resets_between_sessions() -> None:
+    """Each ToolRegistry instance has its own counter; sessions don't share state."""
+    r1 = ToolRegistry(max_calls=1)
+    r1.register("t", lambda _: "ok", {"type": "object"})
+    r1.dispatch("t", {})  # count = 1, no error
+
+    r2 = ToolRegistry(max_calls=1)
+    r2.register("t", lambda _: "ok", {"type": "object"})
+    r2.dispatch("t", {})  # fresh count = 1, should not raise
+
+
+@pytest.mark.asyncio
+async def test_exceeding_limit_emits_max_tool_calls_event_with_correct_fields() -> None:
+    """When tool call limit is exceeded, ToolErrorEvent has tool='max_tool_calls'
+    and error='Research limit reached'."""
+
+    # First Claude response: 2 tool_use blocks; max_calls=1 so second raises
+    first_stream = MagicMock()
+    first_stream.__enter__ = MagicMock(return_value=first_stream)
+    first_stream.__exit__ = MagicMock(return_value=False)
+    first_stream.__iter__ = MagicMock(return_value=iter([]))
+    first_message = MagicMock()
+    first_message.stop_reason = "tool_use"
+    first_message.content = [
+        ToolUseBlock(id="tu_1", name="search_reddit", input={"query": "a"}, type="tool_use"),
+        ToolUseBlock(id="tu_2", name="search_reddit", input={"query": "b"}, type="tool_use"),
+    ]
+    first_stream.get_final_message = MagicMock(return_value=first_message)
+
+    second_stream = MagicMock()
+    second_stream.__enter__ = MagicMock(return_value=second_stream)
+    second_stream.__exit__ = MagicMock(return_value=False)
+    second_stream.__iter__ = MagicMock(
+        return_value=iter([RawMessageStopEvent(type="message_stop")])
+    )
+    second_message = MagicMock()
+    second_message.stop_reason = "end_turn"
+    second_message.content = []
+    second_stream.get_final_message = MagicMock(return_value=second_message)
+
+    mock_client = MagicMock()
+    mock_client.messages.stream.side_effect = [first_stream, second_stream]
+
+    from weles.agent.dispatch import ToolResult
+
+    async def mock_handler(_: dict) -> ToolResult:
+        return ToolResult(summary="ok", data=[])
+
+    registry = ToolRegistry(max_calls=1)
+    registry.register("search_reddit", mock_handler, {"type": "object"})
+
+    events = []
+    async for event in stream_response(mock_client, [], [], [], registry):
+        events.append(event)
+
+    error_events = [e for e in events if isinstance(e, ToolErrorEvent)]
+    max_calls_errors = [e for e in error_events if e.tool == "max_tool_calls"]
+    assert len(max_calls_errors) >= 1
+    assert max_calls_errors[0].error == "Research limit reached"


### PR DESCRIPTION
## Issue

Closes #18

## What this PR does

Adds research synthesis guidance to `research.md`, injects it into the user turn on first research tool call, sends a failure notice to Claude when tools fail, and emits a correct `ToolErrorEvent` when the tool call cap is hit.

## Acceptance criteria

- [x] `research.md` synthesis block committed: signal strength labels, dissenting views, age/discontinuation flags, no manufacturer language, show-reasoning rule, disagreement handling, `[thin data]` definition
- [x] Research guidelines injected as text block into user turn on first `search_reddit` or `search_web` call; once per stream
- [x] Tool failure handling: failed tool names collected per turn; failure notice sent to Claude after tool batch if non-empty
- [x] `[thin data]` condition defined in research prompt (< 3 posts or all searches failed)
- [x] `max_tool_calls_per_turn` enforced: `ToolErrorEvent(tool="max_tool_calls", error="Research limit reached")` emitted; sentinel `"Research limit reached. Synthesise with what you have."` sent to Claude
- [x] `scripts/eval_research.py`: 5 representative queries, manual review only, not CI

## Tests

- [x] All tests specified in the issue are present (`test_synthesis.py`, `test_tool_limit.py` extended)
- [x] `make lint` passes
- [x] `make test` passes (103 passed)
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` — no endpoints changed
- [ ] `docs/architecture.md` — existing dispatch + stream patterns unchanged; injection is additive

## Notes

Research guidance injection uses `resource_path()` so it works both in dev and PyInstaller. `failed_tools` resets per turn (not per stream) so each failure notice is scoped to the batch that just ran. `MaxToolCallsError` is handled separately from generic tool errors — it gets its own sentinel string and does not contribute to `failed_tools`.