### PR TITLE
feat: #19 Shopping mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `GeneratorExit` error logged in LangSmith traces: removed early `break` on `DoneEvent` in the SSE router so `stream_response` exhausts naturally instead of being closed mid-flight
 
 ### v0.4 — Domain Modules
-<!-- Issues #19–22 -->
+
+#### Added
+- Shopping mode prompt (`prompts/modes/shopping.md`): sub-intent classification (category_research, product_lookup, comparative, buy_timing), tool-use sequence, response structures per intent, profile filters for budget_psychology / aesthetic_style / country (#19)
 
 ### v0.5 — Learning Loop
 <!-- Issues #23–28 -->

--- a/src/weles/prompts/modes/shopping.md
+++ b/src/weles/prompts/modes/shopping.md
@@ -1,1 +1,61 @@
-You are in Shopping mode. Research community consensus on products. Structure responses: consensus → failure modes → red flags → buy timing. Apply the user's budget psychology and aesthetic preferences as hard filters.
+# Shopping Mode
+
+You are in Shopping mode. Your job is to surface what actual long-term owners say about products — never manufacturer claims, affiliate copy, or spec-sheet comparisons.
+
+## Sub-intent classification
+
+Classify the user's message into one of these intents without a separate API call:
+
+- **category_research** — "best waterproof jacket under $200", "what boots for wide feet"
+- **product_lookup** — "what do people think of Red Wing 875", "is the Mercer Chef knife worth it"
+- **comparative** — "Danner vs Red Wing for everyday wear", "cast iron vs carbon steel pan"
+- **buy_timing** — "good time to buy a road bike", "when do hiking boots go on sale"
+
+## Tool-use sequence (category_research)
+
+1. Select 3–5 subreddits via `search_reddit` with the appropriate `subcategory` parameter.
+2. Call `search_reddit(query="best {category} {budget}", subreddits=[...], time_filter="year")`.
+3. If results < 3 relevant posts: call `search_web("{category} recommendations site:reddit.com")`.
+4. Credibility labels (`high`/`medium`/`low`/`flagged`) are present in returned data — apply research guidance.
+5. Synthesise with the active research prompt.
+6. Call `add_to_history` for each specifically recommended product with `status="recommended"`.
+7. If `budget_psychology` or `aesthetic_style` is null: ask for at most one missing field.
+
+## Response structures
+
+### category_research
+```
+[signal strength]
+Community pick: {item} — {reason from owner reports}
+Long-term owners report: {durability/longevity}
+Common failure point: {issue}
+Red flags: {QC regressions, quality decline — if any}
+Buy timing: {community-reported sale patterns — if available}
+```
+
+### product_lookup
+```
+[signal strength]
+Community consensus: {summary}
+Reported strengths: {from owner threads}
+Reported weaknesses / failure modes: {recurring complaints}
+What people switched to (and why): {if data exists}
+```
+
+### comparative
+- Never a spec-sheet diff.
+- Frame as community-origin perspectives: "r/X users lean toward A because… r/Y users prefer B because…"
+- Note explicitly when subreddits contradict each other.
+
+### buy_timing
+- Surface community-reported seasonal patterns and sale windows.
+- Note if data is sparse or if the community has no strong opinion.
+
+## Profile filters
+
+Apply these filters when the corresponding profile fields are set:
+
+- `budget_psychology=buy_once_buy_right` → bias toward longevity and owner-tenure posts; surface price-per-use framing.
+- `budget_psychology=good_enough` → surface value picks; note the trade-off vs premium options.
+- `aesthetic_style` → deprioritise results that conflict with the user's stated style; note when top picks clash.
+- `country` → flag limited regional availability when detectable from community discussion.

--- a/src/weles/prompts/modes/shopping.md
+++ b/src/weles/prompts/modes/shopping.md
@@ -13,7 +13,7 @@ Classify the user's message into one of these intents without a separate API cal
 
 ## Tool-use sequence (category_research)
 
-1. Select 3–5 subreddits via `search_reddit` with the appropriate `subcategory` parameter.
+1. Select 3–5 relevant subreddits based on the product category (e.g. r/BuyItForLife, r/malefashionadvice, r/running — use your domain knowledge).
 2. Call `search_reddit(query="best {category} {budget}", subreddits=[...], time_filter="year")`.
 3. If results < 3 relevant posts: call `search_web("{category} recommendations site:reddit.com")`.
 4. Credibility labels (`high`/`medium`/`low`/`flagged`) are present in returned data — apply research guidance.

--- a/tests/integration/test_shopping_mode.py
+++ b/tests/integration/test_shopping_mode.py
@@ -1,0 +1,170 @@
+"""Integration tests for Shopping mode: tool dispatch, history persistence, history injection."""
+
+import contextlib
+import json
+from unittest.mock import MagicMock
+
+from anthropic.types import RawContentBlockDeltaEvent, RawMessageStopEvent, TextDelta, ToolUseBlock
+from fastapi.testclient import TestClient
+from pytest_httpx import HTTPXMock
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE = "https://www.reddit.com"
+
+
+def _post(title: str = "Test Post", score: int = 100, post_id: str = "p1") -> dict:
+    return {
+        "kind": "t3",
+        "data": {
+            "title": title,
+            "url": f"{_BASE}/r/BuyItForLife/comments/{post_id}/",
+            "score": score,
+            "created_utc": 1700000000.0,
+            "subreddit": "BuyItForLife",
+            "selftext": "Great product",
+            "id": post_id,
+            "permalink": f"/r/BuyItForLife/comments/{post_id}/",
+        },
+    }
+
+
+def _listing(*posts: dict) -> dict:
+    return {"kind": "Listing", "data": {"children": list(posts)}}
+
+
+def _comments() -> list:
+    return [
+        {"kind": "Listing", "data": {"children": []}},
+        {"kind": "Listing", "data": {"children": []}},
+    ]
+
+
+def _make_tool_use_client(tool_name: str, tool_input: dict) -> MagicMock:
+    """Claude mock: first call returns one tool_use block, second returns text + end_turn."""
+    # First response: tool_use
+    first_stream = MagicMock()
+    first_stream.__enter__ = MagicMock(return_value=first_stream)
+    first_stream.__exit__ = MagicMock(return_value=False)
+    first_stream.__iter__ = MagicMock(return_value=iter([]))
+    first_msg = MagicMock()
+    first_msg.stop_reason = "tool_use"
+    first_msg.content = [ToolUseBlock(id="tu_1", name=tool_name, input=tool_input, type="tool_use")]
+    first_stream.get_final_message = MagicMock(return_value=first_msg)
+
+    # Second response: text delta + end_turn
+    text_event = RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=0,
+        delta=TextDelta(type="text_delta", text="Here is my analysis."),
+    )
+    stop_event = RawMessageStopEvent(type="message_stop")
+    second_stream = MagicMock()
+    second_stream.__enter__ = MagicMock(return_value=second_stream)
+    second_stream.__exit__ = MagicMock(return_value=False)
+    second_stream.__iter__ = MagicMock(return_value=iter([text_event, stop_event]))
+    second_msg = MagicMock()
+    second_msg.stop_reason = "end_turn"
+    second_msg.content = []
+    second_stream.get_final_message = MagicMock(return_value=second_msg)
+
+    mock_client = MagicMock()
+    mock_client.messages.stream.side_effect = [first_stream, second_stream]
+    return mock_client
+
+
+def _stream_events(client: TestClient, session_id: str, content: str) -> list[tuple[str, dict]]:
+    events = []
+    with client.stream(
+        "POST", f"/sessions/{session_id}/messages", json={"content": content}
+    ) as resp:
+        current_event = None
+        for line in resp.iter_lines():
+            if line.startswith("event:"):
+                current_event = line.split(":", 1)[1].strip()
+            elif line.startswith("data:") and current_event:
+                with contextlib.suppress(json.JSONDecodeError):
+                    events.append((current_event, json.loads(line.split(":", 1)[1].strip())))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_search_reddit_dispatched_in_shopping_mode(
+    client: TestClient, mocker, httpx_mock: HTTPXMock
+) -> None:
+    """When Claude requests search_reddit in shopping mode, the tool is dispatched
+    and a tool_start + tool_end event appear in the SSE stream."""
+    mocker.patch("weles.tools.reddit.asyncio.sleep")
+    httpx_mock.add_response(json=_listing(_post()))
+    httpx_mock.add_response(json=_comments())
+
+    mock_client = _make_tool_use_client(
+        "search_reddit", {"query": "best waterproof jacket", "subreddits": ["malefashionadvice"]}
+    )
+    mocker.patch("weles.api.routers.messages.get_client", return_value=mock_client)
+
+    session_id = client.post("/sessions").json()["id"]
+    client.patch(f"/sessions/{session_id}", json={"mode": "shopping"})
+
+    events = _stream_events(client, session_id, "best waterproof jacket under $200")
+
+    tool_starts = [d for e, d in events if e == "tool_start"]
+    tool_ends = [d for e, d in events if e == "tool_end"]
+    assert any(d["tool"] == "search_reddit" for d in tool_starts)
+    assert any(d["tool"] == "search_reddit" for d in tool_ends)
+
+
+def test_add_to_history_dispatched_and_persisted(client: TestClient, mocker) -> None:
+    """When Claude calls add_to_history in shopping mode, the item is persisted to the DB."""
+    mock_client = _make_tool_use_client(
+        "add_to_history",
+        {
+            "item_name": "Red Wing 875",
+            "category": "footwear",
+            "domain": "shopping",
+            "status": "recommended",
+        },
+    )
+    mocker.patch("weles.api.routers.messages.get_client", return_value=mock_client)
+
+    session_id = client.post("/sessions").json()["id"]
+    client.patch(f"/sessions/{session_id}", json={"mode": "shopping"})
+
+    _stream_events(client, session_id, "what boots should I get")
+
+    history = client.get("/history?domain=shopping").json()
+    assert any(item["item_name"] == "Red Wing 875" for item in history)
+
+
+def test_history_context_injected_for_shopping_domain(client: TestClient, mock_claude) -> None:
+    """When shopping history exists, the history context block is injected into the user turn
+    passed to Claude."""
+    from weles.tools.history_tools import add_to_history_handler
+
+    add_to_history_handler(
+        {
+            "item_name": "Danner Mountain Light",
+            "category": "footwear",
+            "domain": "shopping",
+            "status": "recommended",
+        }
+    )
+
+    session_id = client.post("/sessions").json()["id"]
+    client.patch(f"/sessions/{session_id}", json={"mode": "shopping"})
+
+    with client.stream(
+        "POST", f"/sessions/{session_id}/messages", json={"content": "hiking boots"}
+    ) as resp:
+        for _ in resp.iter_lines():
+            pass  # consume stream
+
+    call_messages = mock_claude.messages.stream.call_args[1]["messages"]
+    last_user_content = call_messages[-1]["content"]
+    assert "Danner Mountain Light" in last_user_content


### PR DESCRIPTION
## Summary

- Full Shopping mode prompt in `src/weles/prompts/modes/shopping.md`: sub-intent classification (category_research, product_lookup, comparative, buy_timing), tool-use sequence with search_reddit + search_web fallback, all 4 response structures, and profile filters for budget_psychology / aesthetic_style / country
- 3 integration tests covering: search_reddit tool dispatch in shopping mode, add_to_history persistence, and history context injection into Claude's user turn

## Acceptance criteria

- [x] `category_research`, `product_lookup`, `comparative`, `buy_timing` sub-intents defined
- [x] Tool-use sequence for `category_research`: search_reddit → optional search_web fallback → credibility → add_to_history
- [x] Response structures for all 4 intents
- [x] Profile filters: budget_psychology, aesthetic_style, country
- [x] Tests: search_reddit dispatched in shopping mode (tool_start + tool_end SSE events)
- [x] Tests: add_to_history dispatched and item persisted to DB
- [x] Tests: history context injected into Claude messages when history exists

## Docs

- [x] CHANGELOG.md updated under v0.4 Domain Modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)