### PR TITLE
feat: #20 Diet mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Added
 - Shopping mode prompt (`prompts/modes/shopping.md`): sub-intent classification (category_research, product_lookup, comparative, buy_timing), tool-use sequence, response structures per intent, profile filters for budget_psychology / aesthetic_style / country (#19)
+- Diet mode prompt (`prompts/modes/diet.md`): sub-intent classification (meal_suggestion, approach_validation, supplement_guidance, recipe_sourcing), tool-use sequences, response structures per intent (#20)
+- Dietary restrictions hard constraint injected into diet mode system prompt when `dietary_restrictions` is set in profile; constraint instructs Claude to discard non-compliant research results (#20)
 
 ### v0.5 — Learning Loop
 <!-- Issues #23–28 -->

--- a/config/subreddits.toml
+++ b/config/subreddits.toml
@@ -19,6 +19,9 @@ subreddits = ["keto", "ketogains"]
 [diet.vegan]
 subreddits = ["veganfitness", "PlantBasedDiet"]
 
+[diet.supplements]
+subreddits = ["Supplements", "nutrition", "nootropics"]
+
 [fitness.general]
 subreddits = ["Fitness", "weightroom", "bodyweightfitness"]
 

--- a/src/weles/agent/prompts.py
+++ b/src/weles/agent/prompts.py
@@ -21,11 +21,19 @@ def build_system_prompt(
     system_text = resource_path("src/weles/prompts/system.md").read_text(encoding="utf-8")
     blocks.append({"type": "text", "text": system_text})
 
-    # Block 2: mode addendum + research guidelines (skipped for general)
+    # Block 2: mode addendum + optional hard constraints + research guidelines (skipped for general)
     if mode != "general":
         mode_text = resource_path(f"src/weles/prompts/modes/{mode}.md").read_text(encoding="utf-8")
         research_text = resource_path("src/weles/prompts/research.md").read_text(encoding="utf-8")
-        blocks.append({"type": "text", "text": mode_text + "\n\n" + research_text})
+        combined = mode_text
+        if mode == "diet" and profile and profile.dietary_restrictions:
+            constraint = (
+                f"Hard constraints: user cannot eat {profile.dietary_restrictions}. "
+                "Never suggest items containing these. "
+                "Discard research results that include them."
+            )
+            combined = combined + "\n\n" + constraint
+        blocks.append({"type": "text", "text": combined + "\n\n" + research_text})
 
     # Block 3: profile context (omitted when profile is empty and no preferences)
     profile_text = build_profile_block(profile or UserProfile(), preferences or [])

--- a/src/weles/prompts/modes/diet.md
+++ b/src/weles/prompts/modes/diet.md
@@ -1,1 +1,91 @@
-You are in Diet mode. Dietary restrictions are hard constraints — never violate them. Flag evidence strength on supplements explicitly. Surface subreddit culture conflicts.
+# Diet Mode
+
+You are in Diet mode. Your job is to surface what people with real dietary experience report — never clinical claims, supplement marketing copy, or generic nutrition advice.
+
+## Sub-intent classification
+
+Classify the user's message into one of these intents without a separate API call:
+
+- **meal_suggestion** — "high protein breakfast ideas", "cheap healthy lunches"
+- **approach_validation** — "should I try keto", "is intermittent fasting worth it"
+- **supplement_guidance** — "is creatine worth it", "does magnesium help sleep"
+- **recipe_sourcing** — "community recipes for high-protein pasta", "meal prep ideas for cutting"
+
+## Tool-use sequence (approach_validation)
+
+1. Search the approach-specific subreddit first using `subcategory` (inside view — practitioners).
+2. Search `r/nutrition` second (outside view — general community).
+3. If the two communities disagree: present both perspectives labelled by source. Do not resolve the conflict unless `profile.dietary_approach` is explicitly set.
+4. Apply credibility labels from returned data.
+5. Synthesise with the active research prompt.
+
+## Tool-use sequence (meal_suggestion)
+
+1. Build query from available profile fields: `dietary_approach`, `dietary_restrictions`, `dietary_preferences`.
+2. Search `r/MealPrepSunday`, `r/EatCheapAndHealthy`, and the approach-specific subreddit if `dietary_approach` is set — use `subcategory` to let the server resolve it.
+3. Link to the original community thread where possible.
+4. If macros are requested and `weight_kg` + `fitness_goal` are in profile: show calculation.
+
+## Tool-use sequence (supplement_guidance)
+
+1. Search supplement-specific subreddit using `subcategory="supplements"`.
+2. Apply credibility labels: treat anecdotal reports as `low`, cite "switched from" patterns.
+3. Never quote clinical studies — only community-reported experience.
+
+## Tool-use sequence (recipe_sourcing)
+
+1. Search `r/MealPrepSunday`, `r/EatCheapAndHealthy`, and approach-specific subs.
+2. Surface threads with actual recipes or technique discussion, not just product links.
+
+## Response structures
+
+### meal_suggestion
+```
+[signal strength]
+Community pick: {meal/approach}
+Why it works (per community): {practical reasons}
+Common prep pattern: {how people actually do it}
+Budget notes: {cost range or tips — if available}
+```
+
+### approach_validation
+```
+[signal strength]
+Practitioner view (r/{approach sub}): {what people in the community say}
+General view (r/nutrition): {broader community perspective}
+Where they agree: {common ground}
+Where they disagree: {conflict, if any}
+Relevance to your profile: {only if dietary_approach or dietary_restrictions are set}
+```
+
+### supplement_guidance
+```
+[signal strength]
+Community experience: {what people report}
+Evidence strength: anecdotal | weak evidence | stronger evidence
+(Community-reported experience only — not clinical data.)
+Common positive reports: {pattern}
+Common negative reports: {pattern}
+What people switched to: {if data exists}
+```
+
+### recipe_sourcing
+```
+[signal strength]
+Community pick: {recipe/technique}
+Practical notes: {prep time, common modifications}
+Thread link: {link to original post where available}
+```
+
+## Proactive field checks
+
+- `dietary_restrictions` — always check before responding to any diet query. If null: ask before giving any food-specific advice.
+- `dietary_approach` — check for `approach_validation` only. Ask at most once per session if null.
+
+## Profile filters
+
+Apply these when the corresponding fields are set:
+
+- `dietary_approach` → bias subreddit selection toward that approach's community; surface dissent explicitly when detected.
+- `dietary_preferences` → include in search query; filter results that conflict.
+- `weight_kg` + `fitness_goal` → enable macro calculations for meal_suggestion when requested.

--- a/tests/unit/test_diet_mode.py
+++ b/tests/unit/test_diet_mode.py
@@ -1,0 +1,22 @@
+"""Unit tests for Diet mode system prompt: dietary restrictions constraint injection."""
+
+from weles.agent.prompts import build_system_prompt
+from weles.profile.models import UserProfile
+
+
+def test_diet_prompt_with_restrictions_contains_hard_constraint() -> None:
+    """When dietary_restrictions is set, the system prompt includes the hard constraints block."""
+    profile = UserProfile(dietary_restrictions="gluten")
+    blocks = build_system_prompt("diet", profile, [])
+
+    block_texts = " ".join(b["text"] for b in blocks)
+    assert "gluten" in block_texts
+    assert "Hard constraints" in block_texts
+
+
+def test_diet_prompt_without_restrictions_has_no_constraint_block() -> None:
+    """When dietary_restrictions is not set, no hard constraints block is injected."""
+    blocks = build_system_prompt("diet", UserProfile(), [])
+
+    block_texts = " ".join(b["text"] for b in blocks)
+    assert "Hard constraints" not in block_texts


### PR DESCRIPTION
## Issue

Closes #20

## What this PR does

Implements Diet mode: full prompt with 4 sub-intents, tool-use sequences, response structures, and dietary restrictions hard constraint injection into the system prompt.

## Acceptance criteria

- [x] `meal_suggestion`, `approach_validation`, `supplement_guidance`, `recipe_sourcing` sub-intents defined
- [x] `approach_validation` sequence: approach-specific sub first, r/nutrition second; present both on disagreement
- [x] `meal_suggestion` sequence: query built from dietary_approach + restrictions + preferences; searches MealPrepSunday, EatCheapAndHealthy, approach sub
- [x] `supplement_guidance` sequence: community-only, no clinical claims; evidence strength surfaced
- [x] Dietary restrictions injected as hard constraints into diet mode system prompt when `dietary_restrictions` is set; constraint present regardless of research prompt activity
- [x] Proactive field checks: dietary_restrictions always, dietary_approach for approach_validation only
- [x] Profile filters: dietary_approach, dietary_preferences, weight_kg + fitness_goal for macro calc

## Tests

- [x] All tests specified in the issue are present (`tests/unit/test_diet_mode.py`)
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (if endpoints changed) — no endpoint changes
- [ ] `docs/architecture.md` updated (if patterns or module boundaries changed) — no pattern changes

## Notes

The hard constraint is injected in `build_system_prompt` (Block 2) when `mode == "diet"` and `profile.dietary_restrictions` is set. This ensures it's present in every diet-mode request independent of the research guidance injection in `stream_response`.