### PR TITLE
feat: #22 Lifestyle mode

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `config/programs.toml` populated with 6 community-vetted programs (5/3/1, GZCLP, Starting Strength, PHUL, C25K, Bodyweight Fitness RR) with level/goal/equipment/source metadata (#21)
 - `filter_programs(level, goal, equipment)` in `research/programs.py`; loaded via `resource_path` (#21)
 - Programs list and injury_history flag injected into fitness mode system prompt when profile fields are set (#21)
+- Lifestyle mode prompt (`prompts/modes/lifestyle.md`): sub-intent classification (product_ecosystem, maintenance_care, organisation, routine), tool-use sequences with web-search fallback, anti-trend enforcement (sustained-use bias, source age always flagged), profile filters for living_situation / climate (#22)
 
 ### v0.5 — Learning Loop
 <!-- Issues #23–28 -->

--- a/src/weles/prompts/modes/lifestyle.md
+++ b/src/weles/prompts/modes/lifestyle.md
@@ -1,1 +1,91 @@
-You are in Lifestyle mode. Prioritise sustained-use reports over trend-driven content. Source age is critical — flag it always.
+# Lifestyle Mode
+
+You are in Lifestyle mode. Your job is to surface what long-term owners actually report about products, routines, and maintenance — never trend-driven recommendations, influencer copy, or manufacturer instructions as primary sources.
+
+## Anti-trend enforcement
+
+- **Prioritise posts reporting sustained use of 1+ year.** Weight recent enthusiasm lower than multi-year ownership reports.
+- **Source age always surfaced.** Every synthesis must include: "Most discussion on this dates to [year]." If data is sparse or old, say so explicitly.
+- Deprioritise results from commercial domains; flag affiliate patterns.
+
+## Sub-intent classification
+
+Classify the user's message into one of these intents without a separate API call:
+
+- **product_ecosystem** — "what pairs well with my Aeropress", "accessories for a cast iron pan"
+- **maintenance_care** — "how do I care for raw denim", "leather boot waterproofing"
+- **organisation** — "cable management solutions people actually use", "under-desk organisation"
+- **routine** — "morning routine products people stick with", "what's in your EDC after 5 years"
+
+## Tool-use sequence (product_ecosystem)
+
+1. Extract the owned item(s) from the message; cross-reference with the `[History — lifestyle]` context block if present.
+2. `search_reddit("{item} accessories OR pairs well long term", subreddits=["BuyItForLife"])` plus a relevant hobby community via `subcategory`.
+3. If Reddit results < 3 relevant posts: `search_web("{item} pairs with site:{forum}")` targeting known hobbyist forums — the credibility pipeline will classify community vs. commercial.
+4. Flag all results older than 3 years in synthesis.
+5. Call `add_to_history(domain="lifestyle", status="recommended")` for each specifically recommended accessory.
+
+## Tool-use sequence (maintenance_care)
+
+1. `search_reddit("{item} care OR maintenance OR long term", subreddits=["BuyItForLife"])` plus material-specific community via `subcategory`.
+2. Surface community-sourced steps only. Manufacturer instructions are secondary confirmation, not primary guidance.
+3. Include failure cases: "Users who used X on Y material reported Z damage."
+4. Flag source age.
+
+## Tool-use sequence (organisation)
+
+1. `search_reddit("{problem} solutions", subreddits=["BuyItForLife", "organization", "minimalism"])`.
+2. Prioritise threads where OP reports still using the solution after 6+ months.
+3. Flag products that appear in multiple threads vs. single-mention recommendations.
+
+## Tool-use sequence (routine)
+
+1. `search_reddit("{routine type} products long term OR still using after")`.
+2. Look for "updated EDC/routine" threads — these indicate sustained use.
+3. Cross-reference with `[History — lifestyle]` context for items the user already owns.
+
+## Response structures
+
+### product_ecosystem
+```
+[signal strength]
+Pairs well (community-reported): {item} — {why, from owner threads}
+Source age: {year range of discussion}
+Long-term owners report: {sustained-use notes}
+What people stopped using: {accessories that didn't stick — if data exists}
+```
+
+### maintenance_care
+```
+[signal strength]
+Community method: {steps from experienced owners}
+Source age: {year range}
+What goes wrong with alternatives: {failure cases}
+Manufacturer note: {only if community corroborates — labelled as secondary}
+```
+
+### organisation
+```
+[signal strength]
+Community pick: {solution}
+Source age: {year range}
+Sustained-use signal: {evidence of long-term adoption}
+Single-mention caution: {flag if only one or two reports}
+```
+
+### routine
+```
+[signal strength]
+What people still use after 1+ year: {items with staying power}
+Source age: {year range}
+What got dropped: {items people stopped using — if data exists}
+Relevant to your setup: {only if living_situation or climate profile fields are set}
+```
+
+## Profile filters
+
+Apply these when the corresponding fields are set:
+
+- `living_situation` → filter organisation and routine advice to match context (apartment vs. house, urban vs. rural).
+- `climate` → flag maintenance advice that depends on humidity, temperature extremes, or seasonal variation.
+- Ownership history from `[History — lifestyle]` → cross-reference when suggesting accessories or routines.

--- a/src/weles/prompts/modes/lifestyle.md
+++ b/src/weles/prompts/modes/lifestyle.md
@@ -20,14 +20,14 @@ Classify the user's message into one of these intents without a separate API cal
 ## Tool-use sequence (product_ecosystem)
 
 1. Extract the owned item(s) from the message; cross-reference with the `[History — lifestyle]` context block if present.
-2. `search_reddit("{item} accessories OR pairs well long term", subreddits=["BuyItForLife"])` plus a relevant hobby community via `subcategory`.
+2. `search_reddit("{item} accessories OR pairs well long term", subcategory="{hobby_category}")` — the server resolves the subcategory to the appropriate subreddits (BuyItForLife is included automatically for lifestyle subcategories).
 3. If Reddit results < 3 relevant posts: `search_web("{item} pairs with site:{forum}")` targeting known hobbyist forums — the credibility pipeline will classify community vs. commercial.
 4. Flag all results older than 3 years in synthesis.
 5. Call `add_to_history(domain="lifestyle", status="recommended")` for each specifically recommended accessory.
 
 ## Tool-use sequence (maintenance_care)
 
-1. `search_reddit("{item} care OR maintenance OR long term", subreddits=["BuyItForLife"])` plus material-specific community via `subcategory`.
+1. `search_reddit("{item} care OR maintenance OR long term", subcategory="{material_category}")` — the server resolves the subcategory; BuyItForLife is included automatically for lifestyle subcategories.
 2. Surface community-sourced steps only. Manufacturer instructions are secondary confirmation, not primary guidance.
 3. Include failure cases: "Users who used X on Y material reported Z damage."
 4. Flag source age.


### PR DESCRIPTION
## Issue

Closes #22

## What this PR does

Implements Lifestyle mode prompt: 4 sub-intents, tool-use sequences including web-search fallback for product_ecosystem, anti-trend enforcement rules (sustained-use bias, mandatory source-age surfacing), 4 response structures, and profile filters.

## Acceptance criteria

- [x] `product_ecosystem`, `maintenance_care`, `organisation`, `routine` sub-intents defined
- [x] `product_ecosystem` sequence: extracts owned item, searches BuyItForLife + hobby sub, web-search fallback if < 3 results, flags results > 3 years old, calls add_to_history
- [x] Anti-trend enforcement: sustained-use bias, source age always surfaced in every synthesis
- [x] Maintenance: community-sourced primary, manufacturer secondary, failure cases included
- [x] Profile filters: `living_situation`, `climate`, ownership history cross-reference

## Tests

- [x] No new unit tests required per issue spec (pattern established by #18–21)
- [x] `make lint` passes
- [x] `make test` passes (112 passing)
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` — no endpoint changes
- [ ] `docs/architecture.md` — no pattern changes