### PR TITLE
feat: #24 session start orchestrator

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `maybe_compress_context(session_id, client, session)` in `agent/compression.py`: when `estimated_tokens > 0.8 × CONTEXT_WINDOW`, summarises the oldest 25% of user+assistant pairs; the last 10 messages are never touched; updates DB and in-memory session (#23)
 - Context compression triggered as a background task after every SSE turn in `api/routers/messages.py` (#23)
 
+#### Added
+- `run_session_start_checks(db)` in `api/session_start.py`: orchestrates all session-start checks in order — passive pattern detection, decay, follow-up, check-in; returns `SessionStartResult{prompt, notices}`; at most one user-facing prompt (#24)
+- Passive pattern detection writes `preferences` row with `source="agent_inferred"` when ≥3 history items are skipped in the same domain+category (#24)
+
+#### Changed
+- `POST /sessions` returns `session_start_prompt: {prompt, notices}` from the orchestrator instead of a static `null` (#24)
+
 #### Fixed
 - `tool_result` blocks now appear before `text` blocks in user messages following a tool-use turn; previous ordering caused `BadRequestError` from the Anthropic API (#23)
 

--- a/src/weles/api/routers/sessions.py
+++ b/src/weles/api/routers/sessions.py
@@ -5,6 +5,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from weles.api.session_start import run_session_start_checks
 from weles.db.connection import get_db
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
@@ -45,12 +46,13 @@ async def create_session() -> dict[str, Any]:
         (session_id, now),
     )
     conn.commit()
+    checks = run_session_start_checks(conn)
     return {
         "id": session_id,
         "title": None,
         "mode": "general",
         "created_at": now.isoformat(),
-        "session_start_prompt": None,
+        "session_start_prompt": checks.to_dict(),
     }
 
 

--- a/src/weles/api/session_start.py
+++ b/src/weles/api/session_start.py
@@ -1,0 +1,192 @@
+"""Session start orchestrator.
+
+Runs all session-start checks in order; returns at most one user-facing prompt.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from weles.db.connection import get_db
+from weles.db.settings_repo import get_setting
+
+# Maps profile field → decay_thresholds category key
+_FIELD_DECAY_CATEGORY: dict[str, str] = {
+    "fitness_goal": "goals",
+    "dietary_goal": "goals",
+    "lifestyle_focus": "goals",
+    "fitness_level": "fitness_level",
+    "dietary_approach": "dietary_approach",
+    "height_cm": "body_metrics",
+    "weight_kg": "body_metrics",
+    "build": "body_metrics",
+    "aesthetic_style": "taste_lifestyle",
+    "activity_level": "taste_lifestyle",
+    "living_situation": "taste_lifestyle",
+    "climate": "taste_lifestyle",
+    "budget_psychology": "taste_lifestyle",
+}
+
+
+@dataclass
+class SessionStartPrompt:
+    type: str  # "follow_up" | "check_in" | "decay"
+    message: str
+
+
+@dataclass
+class SessionStartResult:
+    prompt: SessionStartPrompt | None = None
+    notices: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "prompt": (
+                {"type": self.prompt.type, "message": self.prompt.message} if self.prompt else None
+            ),
+            "notices": self.notices,
+        }
+
+
+def _step1_passive_patterns(conn: sqlite3.Connection) -> None:
+    """Detect skip patterns (≥3 skipped in same domain+category) and write inferred preferences.
+
+    No user-facing prompt is generated.
+    """
+    rows = conn.execute(
+        "SELECT domain, category, COUNT(*) AS cnt FROM history"
+        " WHERE status = 'skipped' GROUP BY domain, category HAVING COUNT(*) >= 3"
+    ).fetchall()
+    for row in rows:
+        dimension = f"skip/{row['domain']}/{row['category']}"
+        existing = conn.execute(
+            "SELECT id FROM preferences WHERE dimension = ?", (dimension,)
+        ).fetchone()
+        if existing:
+            continue
+        conn.execute(
+            "INSERT INTO preferences (id, dimension, value, reason, source, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                str(uuid.uuid4()),
+                dimension,
+                "dislikes",
+                f"Skipped {row['cnt']} times in {row['category']}",
+                "agent_inferred",
+                datetime.utcnow(),
+            ),
+        )
+    conn.commit()
+
+
+def _step2_decay_check(conn: sqlite3.Connection) -> SessionStartPrompt | None:
+    """Return a decay prompt when any tracked profile field is older than its threshold."""
+    row = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
+    if row is None:
+        return None
+    timestamps: dict[str, str] = json.loads(row["field_timestamps"] or "{}")
+    if not timestamps:
+        return None
+
+    thresholds_raw = get_setting("decay_thresholds") or {}
+    thresholds: dict[str, int] = thresholds_raw if isinstance(thresholds_raw, dict) else {}
+    now = datetime.utcnow()
+
+    for field_name, category in _FIELD_DECAY_CATEGORY.items():
+        ts_str = timestamps.get(field_name)
+        if not ts_str:
+            continue
+        value = row[field_name]
+        if value is None:
+            continue
+        threshold_days = thresholds.get(category, 365)
+        try:
+            ts = datetime.fromisoformat(ts_str)
+        except ValueError:
+            continue
+        age_days = (now - ts).days
+        if age_days >= threshold_days:
+            label = field_name.replace("_", " ")
+            return SessionStartPrompt(
+                type="decay",
+                message=(
+                    f"Your {label} was last set {age_days} days ago as '{value}'. Still accurate?"
+                ),
+            )
+    return None
+
+
+def _step3_followup_check(conn: sqlite3.Connection) -> SessionStartPrompt | None:
+    """Return a follow-up prompt when a recommended item has passed its follow_up_due_at."""
+    now = datetime.utcnow()
+    row = conn.execute(
+        "SELECT * FROM history WHERE status = 'recommended'"
+        " AND follow_up_due_at IS NOT NULL AND follow_up_due_at <= ?"
+        " ORDER BY follow_up_due_at ASC LIMIT 1",
+        (now,),
+    ).fetchone()
+    if row is None:
+        return None
+    return SessionStartPrompt(
+        type="follow_up",
+        message=f"Did you end up getting {row['item_name']}?",
+    )
+
+
+def _step4_checkin_check(conn: sqlite3.Connection) -> SessionStartPrompt | None:
+    """Return a check-in prompt when a bought/tried item has passed its check_in_due_at."""
+    now = datetime.utcnow()
+    row = conn.execute(
+        "SELECT * FROM history WHERE status IN ('bought', 'tried')"
+        " AND check_in_due_at IS NOT NULL AND check_in_due_at <= ?"
+        " ORDER BY check_in_due_at ASC LIMIT 1",
+        (now,),
+    ).fetchone()
+    if row is None:
+        return None
+    verb = "bought" if row["status"] == "bought" else "started"
+    try:
+        created = datetime.fromisoformat(str(row["created_at"]))
+        days = (now - created).days
+    except (ValueError, TypeError):
+        days = 0
+    return SessionStartPrompt(
+        type="check_in",
+        message=f"It's been {days} days since you {verb} {row['item_name']}. How's it going?",
+    )
+
+
+def run_session_start_checks(conn: sqlite3.Connection | None = None) -> SessionStartResult:
+    """Run all session-start checks in order; return at most one user-facing prompt.
+
+    Execution order:
+    1. Passive pattern detection (no prompt; writes inferred preferences)
+    2. Profile decay check
+    3. Follow-up check (skipped if step 2 produced a prompt)
+    4. Check-in check (skipped if step 2 or 3 produced a prompt)
+    5. QC / proactive surfacing (notices only; independent of prompt — implemented in #31)
+    """
+    if conn is None:
+        conn = get_db()
+
+    result = SessionStartResult()
+
+    _step1_passive_patterns(conn)
+
+    result.prompt = _step2_decay_check(conn)
+
+    if result.prompt is None:
+        result.prompt = _step3_followup_check(conn)
+
+    if result.prompt is None:
+        result.prompt = _step4_checkin_check(conn)
+
+    # Step 5: QC / proactive surfacing (notices only) — implemented in #31
+    # result.notices = _step5_qc_notices(conn)
+
+    return result

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -6,7 +6,7 @@ def test_post_sessions_returns_201(client):
     assert body["title"] is None
     assert body["mode"] == "general"
     assert "created_at" in body
-    assert body["session_start_prompt"] is None
+    assert body["session_start_prompt"] == {"prompt": None, "notices": []}
 
 
 def test_get_sessions_empty_on_fresh_db(client):

--- a/tests/unit/test_session_start.py
+++ b/tests/unit/test_session_start.py
@@ -1,0 +1,141 @@
+"""Unit tests for the session start orchestrator."""
+
+import json
+import uuid
+from datetime import datetime, timedelta
+
+from weles.api.session_start import run_session_start_checks
+
+
+def _insert_history(
+    conn,
+    item_name: str,
+    domain: str,
+    category: str,
+    status: str,
+    follow_up_due_at=None,
+    check_in_due_at=None,
+) -> None:
+    conn.execute(
+        "INSERT INTO history"
+        " (id, item_name, category, domain, status, follow_up_due_at, check_in_due_at, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            str(uuid.uuid4()),
+            item_name,
+            category,
+            domain,
+            status,
+            follow_up_due_at,
+            check_in_due_at,
+            datetime.utcnow(),
+        ),
+    )
+    conn.commit()
+
+
+def _set_profile_field_with_timestamp(conn, field_name: str, value: str, days_ago: int) -> None:
+    ts = (datetime.utcnow() - timedelta(days=days_ago)).isoformat()
+    existing = conn.execute("SELECT id FROM profile WHERE id = 1").fetchone()
+    if existing is None:
+        conn.execute(
+            "INSERT INTO profile (id, field_timestamps) VALUES (1, ?)",
+            (json.dumps({field_name: ts}),),
+        )
+    else:
+        profile = conn.execute("SELECT field_timestamps FROM profile WHERE id = 1").fetchone()
+        timestamps = json.loads(profile["field_timestamps"] or "{}")
+        timestamps[field_name] = ts
+        conn.execute(
+            "UPDATE profile SET field_timestamps = ? WHERE id = 1",
+            (json.dumps(timestamps),),
+        )
+    conn.execute(f"UPDATE profile SET {field_name} = ? WHERE id = 1", (value,))  # noqa: S608
+    conn.commit()
+
+
+def test_no_due_items_returns_empty(tmp_db) -> None:
+    """With no due items, returns {prompt: None, notices: []}."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    result = run_session_start_checks(conn)
+    assert result.prompt is None
+    assert result.notices == []
+
+
+def test_decay_wins_over_followup(tmp_db) -> None:
+    """With decay due AND follow-up due, decay prompt is returned (decay wins)."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    # Fitness level set 200 days ago (threshold = 90 days)
+    _set_profile_field_with_timestamp(conn, "fitness_level", "beginner", 200)
+    # Follow-up also due
+    past = datetime.utcnow() - timedelta(days=1)
+    _insert_history(
+        conn, "Running Shoes", "shopping", "footwear", "recommended", follow_up_due_at=past
+    )
+
+    result = run_session_start_checks(conn)
+    assert result.prompt is not None
+    assert result.prompt.type == "decay"
+
+
+def test_followup_wins_over_checkin(tmp_db) -> None:
+    """With follow-up due AND check-in due, follow-up prompt is returned."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    past = datetime.utcnow() - timedelta(days=1)
+    _insert_history(
+        conn, "Foam Roller", "fitness", "recovery", "recommended", follow_up_due_at=past
+    )
+    _insert_history(conn, "GZCLP", "fitness", "program", "bought", check_in_due_at=past)
+
+    result = run_session_start_checks(conn)
+    assert result.prompt is not None
+    assert result.prompt.type == "follow_up"
+
+
+def test_checkin_when_only_due(tmp_db) -> None:
+    """With only a check-in due, check-in prompt is returned."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    past = datetime.utcnow() - timedelta(days=1)
+    _insert_history(conn, "Starting Strength", "fitness", "program", "bought", check_in_due_at=past)
+
+    result = run_session_start_checks(conn)
+    assert result.prompt is not None
+    assert result.prompt.type == "check_in"
+
+
+def test_passive_detection_writes_preference(tmp_db) -> None:
+    """Passive detection writes a preference when ≥3 items skipped in the same category."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    for i in range(3):
+        _insert_history(conn, f"Keto Bar {i}", "diet", "keto_snacks", "skipped")
+
+    run_session_start_checks(conn)
+
+    pref = conn.execute(
+        "SELECT * FROM preferences WHERE dimension = ?", ("skip/diet/keto_snacks",)
+    ).fetchone()
+    assert pref is not None
+    assert pref["value"] == "dislikes"
+    assert pref["source"] == "agent_inferred"
+
+
+def test_passive_detection_returns_no_prompt(tmp_db) -> None:
+    """Passive pattern detection does not produce a user-facing prompt."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    for i in range(3):
+        _insert_history(conn, f"Supplement {i}", "diet", "supplements", "skipped")
+
+    result = run_session_start_checks(conn)
+    assert result.prompt is None


### PR DESCRIPTION
## Summary

- `run_session_start_checks(db) -> SessionStartResult` in `api/session_start.py` — orchestrates all session-start checks in strict order
- 5-step execution: (1) passive pattern detection → writes inferred preferences, no prompt; (2) profile decay check; (3) follow-up due check; (4) check-in due check; (5) QC/proactive surfacing stub (returns [] for now, implemented in #31)
- `POST /sessions` now returns `session_start_prompt: {prompt, notices}` instead of static `null`
- Passive detection: ≥3 skips in same domain+category → writes `preferences` row with `source="agent_inferred"`

## Acceptance criteria

- [x] `run_session_start_checks(db) -> SessionStartResult` in `api/session_start.py`
- [x] `SessionStartResult`: `{prompt: SessionStartPrompt | None, notices: list[str]}`
- [x] Strict execution order: passive patterns → decay → follow-up → check-in → QC notices
- [x] At most one user-facing prompt
- [x] `POST /sessions` returns orchestrator result in `session_start_prompt`

## Tests

- [x] No due items → `{prompt: None, notices: []}`
- [x] Decay + follow-up due → decay wins
- [x] Follow-up + check-in due → follow-up wins
- [x] Check-in only due → check-in prompt
- [x] Passive detection writes preference on ≥3 skips in same category
- [x] Passive detection returns no prompt

## Docs

- [x] `CHANGELOG.md` updated under v0.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)