### PR TITLE
feat: #26 outcome check-ins

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `run_session_start_checks(db)` in `api/session_start.py`: orchestrates all session-start checks in order — passive pattern detection, decay, follow-up, check-in; returns `SessionStartResult{prompt, notices}`; at most one user-facing prompt (#24)
 - Passive pattern detection writes `preferences` row with `source="agent_inferred"` when ≥3 history items are skipped in the same domain+category (#24)
 - `check_follow_up(db) -> SessionStartPrompt | None` in `api/session_start.py`; queries oldest overdue recommended item; returns `follow_up` prompt or `None` (#25)
+- `snooze_follow_up(item_id, cadence_days)` in `history_repo.py`; `snooze_follow_up` Claude tool registered in registry (#25)
+- `check_check_in(db) -> SessionStartPrompt | None` in `api/session_start.py`; queries oldest overdue bought/tried item; returns `check_in` prompt or `None` (#26)
+- `snooze_check_in(item_id, days=30)` in `history_repo.py`; `snooze_check_in` Claude tool registered in registry for "Remind me later" response (#26)
 
 #### Changed
 - `POST /sessions` returns `session_start_prompt: {prompt, notices}` from the orchestrator instead of a static `null` (#24)

--- a/src/weles/agent/stream.py
+++ b/src/weles/agent/stream.py
@@ -72,6 +72,8 @@ def _build_description(tool_name: str, tool_input: dict[str, Any]) -> str:
         return f"Saving {field} to your profile…"
     if tool_name == "snooze_follow_up":
         return "Snoozing follow-up reminder…"
+    if tool_name == "snooze_check_in":
+        return "Snoozing check-in reminder…"
     return f"Running {tool_name}…"
 
 

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -31,8 +31,10 @@ from weles.db.settings_repo import get_setting
 from weles.research.routing import get_subcategories, get_subreddits
 from weles.tools.history_tools import (
     ADD_TO_HISTORY_SCHEMA,
+    SNOOZE_CHECK_IN_SCHEMA,
     SNOOZE_FOLLOW_UP_SCHEMA,
     add_to_history_handler,
+    snooze_check_in_handler,
     snooze_follow_up_handler,
 )
 from weles.tools.profile_tools import SAVE_PROFILE_FIELD_SCHEMA, save_profile_field_handler
@@ -208,6 +210,11 @@ async def post_message(session_id: str, body: MessageBody, request: Request) -> 
             "snooze_follow_up",
             snooze_follow_up_handler,
             SNOOZE_FOLLOW_UP_SCHEMA,
+        )
+        registry.register(
+            "snooze_check_in",
+            snooze_check_in_handler,
+            SNOOZE_CHECK_IN_SCHEMA,
         )
         registry.register(
             "search_reddit",

--- a/src/weles/api/session_start.py
+++ b/src/weles/api/session_start.py
@@ -148,8 +148,14 @@ def _step3_followup_check(conn: sqlite3.Connection) -> SessionStartPrompt | None
     return check_follow_up(conn)
 
 
-def _step4_checkin_check(conn: sqlite3.Connection) -> SessionStartPrompt | None:
-    """Return a check-in prompt when a bought/tried item has passed its check_in_due_at."""
+def check_check_in(conn: sqlite3.Connection | None = None) -> SessionStartPrompt | None:
+    """Return a check-in prompt when a bought/tried item has passed its check_in_due_at.
+
+    Queries: SELECT * FROM history WHERE status IN ('bought','tried')
+             AND check_in_due_at <= now() ORDER BY check_in_due_at ASC LIMIT 1
+    """
+    if conn is None:
+        conn = get_db()
     now = datetime.utcnow()
     row = conn.execute(
         "SELECT * FROM history WHERE status IN ('bought', 'tried')"
@@ -169,6 +175,10 @@ def _step4_checkin_check(conn: sqlite3.Connection) -> SessionStartPrompt | None:
         type="check_in",
         message=f"It's been {days} days since you {verb} {row['item_name']}. How's it going?",
     )
+
+
+def _step4_checkin_check(conn: sqlite3.Connection) -> SessionStartPrompt | None:
+    return check_check_in(conn)
 
 
 def run_session_start_checks(conn: sqlite3.Connection | None = None) -> SessionStartResult:

--- a/src/weles/db/history_repo.py
+++ b/src/weles/db/history_repo.py
@@ -90,6 +90,22 @@ def add_to_history(
     return dict(row)
 
 
+def snooze_check_in(item_id: str, days: int = 30) -> bool:
+    """Defer a bought/tried item's check_in_due_at by `days` from now.
+
+    Returns True if the row was found and updated, False otherwise.
+    """
+    now = datetime.utcnow()
+    new_due = now + timedelta(days=days)
+    conn = get_db()
+    cur = conn.execute(
+        "UPDATE history SET check_in_due_at = ? WHERE id = ? AND status IN ('bought', 'tried')",
+        (new_due, item_id),
+    )
+    conn.commit()
+    return cur.rowcount > 0
+
+
 def snooze_follow_up(item_id: str, cadence_days: int) -> bool:
     """Defer a recommended item's follow_up_due_at by cadence_days from now.
 

--- a/src/weles/tools/history_tools.py
+++ b/src/weles/tools/history_tools.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from weles.agent.dispatch import ToolResult
 from weles.db.history_repo import add_to_history as _add_to_history
+from weles.db.history_repo import snooze_check_in as _snooze_check_in
 from weles.db.history_repo import snooze_follow_up as _snooze_follow_up
 from weles.db.settings_repo import get_setting
 
@@ -78,5 +79,32 @@ def snooze_follow_up_handler(tool_input: dict[str, Any]) -> ToolResult:
         )
     return ToolResult(
         summary="Follow-up item not found.",
+        data={"item_id": item_id},
+    )
+
+
+SNOOZE_CHECK_IN_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "item_id": {
+            "type": "string",
+            "description": "ID of the history item to snooze (from the check-in prompt context).",
+        },
+    },
+    "required": ["item_id"],
+}
+
+
+def snooze_check_in_handler(tool_input: dict[str, Any]) -> ToolResult:
+    """Defer the check-in for a bought/tried item by 30 days ('Remind me later')."""
+    item_id = tool_input["item_id"]
+    updated = _snooze_check_in(item_id, days=30)
+    if updated:
+        return ToolResult(
+            summary="Check-in snoozed for 30 days.",
+            data={"item_id": item_id, "snoozed_days": 30},
+        )
+    return ToolResult(
+        summary="Check-in item not found.",
         data={"item_id": item_id},
     )

--- a/tests/unit/test_check_in.py
+++ b/tests/unit/test_check_in.py
@@ -1,0 +1,52 @@
+"""Unit tests for outcome check-ins: check_check_in function."""
+
+import uuid
+from datetime import datetime, timedelta
+
+from weles.api.session_start import check_check_in
+
+
+def _insert_history_raw(
+    conn,
+    item_name: str,
+    status: str,
+    check_in_due_at=None,
+) -> None:
+    conn.execute(
+        "INSERT INTO history"
+        " (id, item_name, category, domain, status, check_in_due_at, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            str(uuid.uuid4()),
+            item_name,
+            "program",
+            "fitness",
+            status,
+            check_in_due_at,
+            datetime.utcnow(),
+        ),
+    )
+    conn.commit()
+
+
+def test_check_check_in_no_due_items_returns_none(tmp_db) -> None:
+    """check_check_in with no due items returns None."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    result = check_check_in(conn)
+    assert result is None
+
+
+def test_check_check_in_due_item_returns_prompt(tmp_db) -> None:
+    """check_check_in with a due item returns a check_in prompt containing the item name."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    past = datetime.utcnow() - timedelta(days=1)
+    _insert_history_raw(conn, "GZCLP", "bought", check_in_due_at=past)
+
+    result = check_check_in(conn)
+    assert result is not None
+    assert result.type == "check_in"
+    assert "GZCLP" in result.message


### PR DESCRIPTION
## Summary

- `check_check_in(db=None) -> SessionStartPrompt | None` exposed publicly in `api/session_start.py`; wraps `_step4_checkin_check`
- Queries `history WHERE status IN ('bought','tried') AND check_in_due_at <= now() ORDER BY check_in_due_at ASC LIMIT 1`
- Prompt: "It's been {N} days since you {bought/started} {item_name}. How's it going?"
- `snooze_check_in(item_id, days=30)` added to `history_repo.py` — handles "Remind me later" response
- `snooze_check_in` Claude tool registered in `messages.py`; description wired in `stream.py`

## Acceptance criteria

- [x] `check_check_in(db) -> SessionStartPrompt | None` in `api/session_start.py`
- [x] Correct query with `check_in_due_at <= now()`, ordered oldest-first, limit 1
- [x] Prompt contains item name and days-elapsed; verb is "bought" or "started"
- [x] "Remind me later" → `snooze_check_in` tool defers `check_in_due_at` by 30 days
- [x] Orchestrator order (#24) ensures check-in only surfaces if no follow-up is due

## Tests

- [x] `check_check_in` with no due items returns `None`
- [x] `check_check_in` with due item returns prompt containing item name
- Check-in due dates by domain already tested in #12

## Docs

- [x] `CHANGELOG.md` updated under v0.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)