### PR TITLE
feat: #27 correction memory and passive pattern detection

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `snooze_follow_up(item_id, cadence_days)` in `history_repo.py`; `snooze_follow_up` Claude tool registered in registry (#25)
 - `check_check_in(db) -> SessionStartPrompt | None` in `api/session_start.py`; queries oldest overdue bought/tried item; returns `check_in` prompt or `None` (#26)
 - `snooze_check_in(item_id, days=30)` in `history_repo.py`; `snooze_check_in` Claude tool registered in registry for "Remind me later" response (#26)
+- `update_preference(dimension, value, reason, source)` in `profile_repo.py`; upserts a preference row (#27)
+- `update_preference` Claude tool in `tools/profile_tools.py`; registered in `ToolRegistry`; source always `"user_explicit"` (#27)
+- System prompt instructs Claude to call `update_preference` immediately on user pushback (#27)
+- Passive pattern detection updated: dimension `{domain}.{category}`, value describes skipping pattern, delegates to `update_preference` (#27)
 
 #### Changed
 - `POST /sessions` returns `session_start_prompt: {prompt, notices}` from the orchestrator instead of a static `null` (#24)

--- a/src/weles/agent/stream.py
+++ b/src/weles/agent/stream.py
@@ -74,6 +74,9 @@ def _build_description(tool_name: str, tool_input: dict[str, Any]) -> str:
         return "Snoozing follow-up reminder…"
     if tool_name == "snooze_check_in":
         return "Snoozing check-in reminder…"
+    if tool_name == "update_preference":
+        dimension = tool_input.get("dimension", "preference")
+        return f"Saving preference: {dimension}…"
     return f"Running {tool_name}…"
 
 

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -37,7 +37,12 @@ from weles.tools.history_tools import (
     snooze_check_in_handler,
     snooze_follow_up_handler,
 )
-from weles.tools.profile_tools import SAVE_PROFILE_FIELD_SCHEMA, save_profile_field_handler
+from weles.tools.profile_tools import (
+    SAVE_PROFILE_FIELD_SCHEMA,
+    UPDATE_PREFERENCE_SCHEMA,
+    save_profile_field_handler,
+    update_preference_handler,
+)
 from weles.tools.reddit import SEARCH_REDDIT_SCHEMA, search_reddit_handler
 from weles.tools.web import SEARCH_WEB_SCHEMA, search_web_handler
 from weles.utils.errors import ConfigurationError
@@ -200,6 +205,11 @@ async def post_message(session_id: str, body: MessageBody, request: Request) -> 
             "save_profile_field",
             save_profile_field_handler,
             SAVE_PROFILE_FIELD_SCHEMA,
+        )
+        registry.register(
+            "update_preference",
+            update_preference_handler,
+            UPDATE_PREFERENCE_SCHEMA,
         )
         registry.register(
             "add_to_history",

--- a/src/weles/api/session_start.py
+++ b/src/weles/api/session_start.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
 from weles.db.connection import get_db
+from weles.db.profile_repo import update_preference
 from weles.db.settings_repo import get_setting
 
 # Maps profile field → decay_thresholds category key
@@ -63,25 +63,17 @@ def _step1_passive_patterns(conn: sqlite3.Connection) -> None:
         " WHERE status = 'skipped' GROUP BY domain, category HAVING COUNT(*) >= 3"
     ).fetchall()
     for row in rows:
-        dimension = f"skip/{row['domain']}/{row['category']}"
+        dimension = f"{row['domain']}.{row['category']}"
         existing = conn.execute(
             "SELECT id FROM preferences WHERE dimension = ?", (dimension,)
         ).fetchone()
         if existing:
             continue
-        conn.execute(
-            "INSERT INTO preferences (id, dimension, value, reason, source, created_at)"
-            " VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                str(uuid.uuid4()),
-                dimension,
-                "dislikes",
-                f"Skipped {row['cnt']} times in {row['category']}",
-                "agent_inferred",
-                datetime.utcnow(),
-            ),
+        update_preference(
+            dimension=dimension,
+            value=f"Consistently skips {row['category']} recommendations in {row['domain']}",
+            source="agent_inferred",
         )
-    conn.commit()
 
 
 def _step2_decay_check(conn: sqlite3.Connection) -> SessionStartPrompt | None:

--- a/src/weles/db/profile_repo.py
+++ b/src/weles/db/profile_repo.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import uuid
 from datetime import datetime
 from typing import Any
 
@@ -75,6 +76,32 @@ def update_profile(patch: dict[str, Any]) -> UserProfile:
     except ValidationError:
         logger.exception("Profile row contains invalid data after update; returning empty profile")
         return UserProfile()
+
+
+def update_preference(
+    dimension: str,
+    value: str,
+    reason: str | None = None,
+    source: str = "user_explicit",
+) -> None:
+    """Upsert a preference row. Updates value/reason/source if the dimension already exists."""
+    conn = get_db()
+    existing = conn.execute(
+        "SELECT id FROM preferences WHERE dimension = ?", (dimension,)
+    ).fetchone()
+    if existing:
+        conn.execute(
+            "UPDATE preferences SET value = ?, reason = ?, source = ?, created_at = ?"
+            " WHERE dimension = ?",
+            (value, reason, source, datetime.utcnow(), dimension),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO preferences (id, dimension, value, reason, source, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (str(uuid.uuid4()), dimension, value, reason, source, datetime.utcnow()),
+        )
+    conn.commit()
 
 
 def get_preferences() -> list[Preference]:

--- a/src/weles/prompts/system.md
+++ b/src/weles/prompts/system.md
@@ -1,1 +1,3 @@
 You are Weles. Respond factually and without warmth. No preamble. No trailing summaries. State conclusions directly. When data is limited, say so.
+
+If the user pushes back on a recommendation type or says they're not interested in a category, call `update_preference` immediately.

--- a/src/weles/tools/profile_tools.py
+++ b/src/weles/tools/profile_tools.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from weles.agent.dispatch import ToolResult
+from weles.db.profile_repo import update_preference as _update_preference
 from weles.db.profile_repo import update_profile
 
 _VALID_FIELDS = {
@@ -49,3 +51,35 @@ def save_profile_field(field: str, value: str) -> str:
 
 def save_profile_field_handler(tool_input: dict[str, Any]) -> str:
     return save_profile_field(tool_input["field"], tool_input["value"])
+
+
+UPDATE_PREFERENCE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "dimension": {
+            "type": "string",
+            "description": (
+                "Preference dimension (e.g. 'shopping.footwear', 'diet.supplements'). "
+                "Use 'domain.category' format."
+            ),
+        },
+        "value": {
+            "type": "string",
+            "description": "Preference value (e.g. 'No minimalist styles', 'Avoids whey protein').",
+        },
+        "reason": {
+            "type": "string",
+            "description": "Optional: what the user said or did that prompted this preference.",
+        },
+    },
+    "required": ["dimension", "value"],
+}
+
+
+def update_preference_handler(tool_input: dict[str, Any]) -> ToolResult:
+    """Handle update_preference tool call; always writes with source='user_explicit'."""
+    dimension = tool_input["dimension"]
+    value = tool_input["value"]
+    reason = tool_input.get("reason")
+    _update_preference(dimension=dimension, value=value, reason=reason, source="user_explicit")
+    return ToolResult(summary=f"Saved preference: {value}", data={"dimension": dimension})

--- a/tests/integration/test_preferences_api.py
+++ b/tests/integration/test_preferences_api.py
@@ -1,0 +1,39 @@
+"""Integration tests for preferences API (issue #27)."""
+
+import uuid
+from datetime import datetime
+
+
+def _insert_preference(client) -> str:
+    """Insert a preference directly into the DB and return its id."""
+    from weles.db.connection import get_db
+
+    pref_id = str(uuid.uuid4())
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO preferences (id, dimension, value, reason, source, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        (pref_id, "shopping.footwear", "No minimalist", None, "user_explicit", datetime.utcnow()),
+    )
+    conn.commit()
+    return pref_id
+
+
+def test_delete_preference_removes_row(client) -> None:
+    """DELETE /preferences/{id} removes the row; GET /preferences no longer lists it."""
+    pref_id = _insert_preference(client)
+
+    # Confirm it's there
+    resp = client.get("/preferences")
+    assert resp.status_code == 200
+    ids = [p["id"] for p in resp.json()]
+    assert pref_id in ids
+
+    # Delete it
+    resp = client.delete(f"/preferences/{pref_id}")
+    assert resp.status_code == 204
+
+    # Confirm it's gone
+    resp = client.get("/preferences")
+    ids = [p["id"] for p in resp.json()]
+    assert pref_id not in ids

--- a/tests/unit/test_preferences.py
+++ b/tests/unit/test_preferences.py
@@ -1,0 +1,74 @@
+"""Unit tests for correction memory and passive pattern detection (issue #27)."""
+
+import uuid
+from datetime import datetime
+
+
+def _insert_history(conn, item_name: str, domain: str, category: str, status: str) -> None:
+    conn.execute(
+        "INSERT INTO history (id, item_name, category, domain, status, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        (str(uuid.uuid4()), item_name, category, domain, status, datetime.utcnow()),
+    )
+    conn.commit()
+
+
+def test_update_preference_writes_row(tmp_db) -> None:
+    """update_preference writes a row with the correct dimension, value, and source."""
+    from weles.db.connection import get_db
+    from weles.db.profile_repo import update_preference
+
+    update_preference("shopping.footwear", "No minimalist", source="user_explicit")
+
+    conn = get_db()
+    row = conn.execute("SELECT * FROM preferences WHERE dimension = 'shopping.footwear'").fetchone()
+    assert row is not None
+    assert row["value"] == "No minimalist"
+    assert row["source"] == "user_explicit"
+    assert row["reason"] is None
+
+
+def test_update_preference_appears_in_profile_block(tmp_db) -> None:
+    """Preference row written via update_preference appears in build_profile_block output."""
+    from weles.db.profile_repo import get_preferences, update_preference
+    from weles.profile.context import build_profile_block
+    from weles.profile.models import UserProfile
+
+    update_preference("shopping.footwear", "No minimalist", source="user_explicit")
+
+    prefs = get_preferences()
+    block = build_profile_block(UserProfile(), prefs)
+    assert block is not None
+    assert "No minimalist" in block
+
+
+def test_passive_detection_writes_preference_on_three_skips(tmp_db) -> None:
+    """Passive detection writes one preference when ≥3 items are skipped in same domain+category."""
+    from weles.api.session_start import run_session_start_checks
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    for name in ("Boot A", "Boot B", "Boot C"):
+        _insert_history(conn, name, "shopping", "footwear", "skipped")
+
+    run_session_start_checks(conn)
+
+    row = conn.execute("SELECT * FROM preferences WHERE dimension = 'shopping.footwear'").fetchone()
+    assert row is not None
+    assert row["source"] == "agent_inferred"
+    assert "footwear" in row["value"]
+
+
+def test_passive_detection_does_not_write_on_two_skips(tmp_db) -> None:
+    """Passive detection writes nothing when fewer than 3 items are skipped."""
+    from weles.api.session_start import run_session_start_checks
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    for name in ("Boot A", "Boot B"):
+        _insert_history(conn, name, "shopping", "footwear", "skipped")
+
+    run_session_start_checks(conn)
+
+    row = conn.execute("SELECT * FROM preferences WHERE dimension = 'shopping.footwear'").fetchone()
+    assert row is None

--- a/tests/unit/test_session_start.py
+++ b/tests/unit/test_session_start.py
@@ -122,10 +122,10 @@ def test_passive_detection_writes_preference(tmp_db) -> None:
     run_session_start_checks(conn)
 
     pref = conn.execute(
-        "SELECT * FROM preferences WHERE dimension = ?", ("skip/diet/keto_snacks",)
+        "SELECT * FROM preferences WHERE dimension = ?", ("diet.keto_snacks",)
     ).fetchone()
     assert pref is not None
-    assert pref["value"] == "dislikes"
+    assert "keto_snacks" in pref["value"]
     assert pref["source"] == "agent_inferred"
 
 


### PR DESCRIPTION
## Issue

Closes #27

## What this PR does

Adds `update_preference` as a Claude tool and fixes passive pattern detection to use the correct dimension format.

## Acceptance criteria

- [x] `update_preference(dimension, value, reason=None)` Claude tool in `tools/profile_tools.py`; `source="user_explicit"` when called by Claude
- [x] `update_preference` function in `profile_repo.py`; upserts to `preferences` table; does not touch `profile` table
- [x] Preference immediately injected into profile context block (rebuilt from `get_preferences()` on every request)
- [x] Passive pattern detection in `_step1_passive_patterns` updated: dimension `{domain}.{category}`, value describes pattern, delegates to `update_preference` with `source="agent_inferred"`; skips if dimension already exists
- [x] System prompt: "If the user pushes back on a recommendation type or says they're not interested in a category, call `update_preference` immediately."
- [x] `DELETE /preferences/{id}` already existed and works
- [x] Preferences visible in Information tab via `GET /preferences` (already existed)

## Tests

- [x] All tests specified in the issue are present
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (no endpoint changes)
- [ ] `docs/architecture.md` updated (no structural changes)

## Notes

Updated `test_session_start.py::test_passive_detection_writes_preference` to use the new `{domain}.{category}` dimension format and value pattern (old test asserted `"dislikes"` which was the prior stub value).