### PR TITLE
feat: #28 profile decay and reconfirmation

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `update_preference` Claude tool in `tools/profile_tools.py`; registered in `ToolRegistry`; source always `"user_explicit"` (#27)
 - System prompt instructs Claude to call `update_preference` immediately on user pushback (#27)
 - Passive pattern detection updated: dimension `{domain}.{category}`, value describes skipping pattern, delegates to `update_preference` (#27)
+- `check_decay(profile, thresholds) -> DecayPrompt | None` in `profile/decay.py`; returns prompt for most-overdue stale field; only non-null fields evaluated (#28)
+- `FIELD_DECAY_CATEGORY` mapping moved to `profile/decay.py`; `_step2_decay_check` in session_start delegates to `check_decay` (#28)
 
 #### Changed
 - `POST /sessions` returns `session_start_prompt: {prompt, notices}` from the orchestrator instead of a static `null` (#24)

--- a/src/weles/api/session_start.py
+++ b/src/weles/api/session_start.py
@@ -5,32 +5,15 @@ Runs all session-start checks in order; returns at most one user-facing prompt.
 
 from __future__ import annotations
 
-import json
 import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
 from weles.db.connection import get_db
-from weles.db.profile_repo import update_preference
+from weles.db.profile_repo import get_profile, update_preference
 from weles.db.settings_repo import get_setting
-
-# Maps profile field → decay_thresholds category key
-_FIELD_DECAY_CATEGORY: dict[str, str] = {
-    "fitness_goal": "goals",
-    "dietary_goal": "goals",
-    "lifestyle_focus": "goals",
-    "fitness_level": "fitness_level",
-    "dietary_approach": "dietary_approach",
-    "height_cm": "body_metrics",
-    "weight_kg": "body_metrics",
-    "build": "body_metrics",
-    "aesthetic_style": "taste_lifestyle",
-    "activity_level": "taste_lifestyle",
-    "living_situation": "taste_lifestyle",
-    "climate": "taste_lifestyle",
-    "budget_psychology": "taste_lifestyle",
-}
+from weles.profile.decay import check_decay
 
 
 @dataclass
@@ -77,40 +60,14 @@ def _step1_passive_patterns(conn: sqlite3.Connection) -> None:
 
 
 def _step2_decay_check(conn: sqlite3.Connection) -> SessionStartPrompt | None:
-    """Return a decay prompt when any tracked profile field is older than its threshold."""
-    row = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
-    if row is None:
-        return None
-    timestamps: dict[str, str] = json.loads(row["field_timestamps"] or "{}")
-    if not timestamps:
-        return None
-
+    """Return a decay prompt for the most-overdue stale profile field."""
+    profile = get_profile()
     thresholds_raw = get_setting("decay_thresholds") or {}
     thresholds: dict[str, int] = thresholds_raw if isinstance(thresholds_raw, dict) else {}
-    now = datetime.utcnow()
-
-    for field_name, category in _FIELD_DECAY_CATEGORY.items():
-        ts_str = timestamps.get(field_name)
-        if not ts_str:
-            continue
-        value = row[field_name]
-        if value is None:
-            continue
-        threshold_days = thresholds.get(category, 365)
-        try:
-            ts = datetime.fromisoformat(ts_str)
-        except ValueError:
-            continue
-        age_days = (now - ts).days
-        if age_days >= threshold_days:
-            label = field_name.replace("_", " ")
-            return SessionStartPrompt(
-                type="decay",
-                message=(
-                    f"Your {label} was last set {age_days} days ago as '{value}'. Still accurate?"
-                ),
-            )
-    return None
+    result = check_decay(profile, thresholds)
+    if result is None:
+        return None
+    return SessionStartPrompt(type=result.type, message=result.message)
 
 
 def check_follow_up(conn: sqlite3.Connection | None = None) -> SessionStartPrompt | None:

--- a/src/weles/profile/decay.py
+++ b/src/weles/profile/decay.py
@@ -1,0 +1,76 @@
+"""Profile field decay detection.
+
+Returns a reconfirmation prompt for the most-overdue stale field.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from weles.profile.models import UserProfile, parse_field_timestamps
+
+# Maps profile field name → decay_thresholds settings key
+FIELD_DECAY_CATEGORY: dict[str, str] = {
+    "fitness_goal": "goals",
+    "dietary_goal": "goals",
+    "lifestyle_focus": "goals",
+    "fitness_level": "fitness_level",
+    "dietary_approach": "dietary_approach",
+    "height_cm": "body_metrics",
+    "weight_kg": "body_metrics",
+    "build": "body_metrics",
+    "aesthetic_style": "taste_lifestyle",
+    "activity_level": "taste_lifestyle",
+    "living_situation": "taste_lifestyle",
+    "climate": "taste_lifestyle",
+    "budget_psychology": "taste_lifestyle",
+}
+
+
+@dataclass
+class DecayPrompt:
+    """Prompt returned when a profile field has passed its decay threshold."""
+
+    type: str  # always "decay"
+    message: str
+
+
+def check_decay(profile: UserProfile, thresholds: dict[str, int]) -> DecayPrompt | None:
+    """Return a decay prompt for the most-overdue stale profile field.
+
+    Only non-null fields with a recorded timestamp are evaluated.
+    Returns None when no field has exceeded its threshold.
+    """
+    timestamps = parse_field_timestamps(profile)
+    now = datetime.utcnow()
+
+    best: tuple[int, str, int, str] | None = None  # (overage_days, field_name, age_days, value)
+
+    for field_name, category in FIELD_DECAY_CATEGORY.items():
+        ts_str = timestamps.get(field_name)
+        if not ts_str:
+            continue
+        value = getattr(profile, field_name, None)
+        if value is None:
+            continue
+        threshold_days = thresholds.get(category, 365)
+        try:
+            ts = datetime.fromisoformat(ts_str)
+        except ValueError:
+            continue
+        age_days = (now - ts).days
+        if age_days >= threshold_days:
+            overage = age_days - threshold_days
+            if best is None or overage > best[0]:
+                best = (overage, field_name, age_days, str(value))
+
+    if best is None:
+        return None
+
+    _, field_name, age_days, value_str = best
+    label = field_name.replace("_", " ")
+    return DecayPrompt(
+        type="decay",
+        message=f"Your {label} was last set {age_days} days ago as '{value_str}'. Still accurate?",
+    )

--- a/tests/unit/test_decay.py
+++ b/tests/unit/test_decay.py
@@ -1,0 +1,93 @@
+"""Unit tests for profile field decay detection (issue #28)."""
+
+import json
+from datetime import datetime, timedelta
+
+from weles.profile.decay import check_decay
+from weles.profile.models import UserProfile
+
+_THRESHOLDS = {
+    "goals": 60,
+    "fitness_level": 90,
+    "dietary_approach": 90,
+    "body_metrics": 180,
+    "taste_lifestyle": 365,
+}
+
+
+def _make_profile(**field_ages: int) -> UserProfile:
+    """Build a UserProfile with the given fields set to non-null values,
+    with timestamps aged by the specified number of days.
+    """
+    now = datetime.utcnow()
+    data: dict = {}
+    timestamps: dict = {}
+    defaults = {
+        "fitness_goal": "build muscle",
+        "dietary_goal": "lose weight",
+        "lifestyle_focus": "minimalism",
+        "fitness_level": "intermediate",
+        "dietary_approach": "flexible",
+        "height_cm": 180.0,
+        "weight_kg": 80.0,
+        "build": "athletic",
+        "aesthetic_style": "minimal",
+        "activity_level": "moderate",
+        "living_situation": "urban",
+        "climate": "temperate",
+        "budget_psychology": "good_enough",
+    }
+    for field, days_ago in field_ages.items():
+        data[field] = defaults[field]
+        timestamps[field] = (now - timedelta(days=days_ago)).isoformat()
+    data["field_timestamps"] = json.dumps(timestamps)
+    return UserProfile(**data)
+
+
+def test_check_decay_all_fresh_returns_none() -> None:
+    """check_decay returns None when all fields were updated recently."""
+    profile = _make_profile(fitness_goal=10, fitness_level=30)
+    result = check_decay(profile, _THRESHOLDS)
+    assert result is None
+
+
+def test_check_decay_stale_field_returns_prompt() -> None:
+    """check_decay returns a decay prompt when fitness_goal is 61 days old (threshold: 60)."""
+    profile = _make_profile(fitness_goal=61)
+    result = check_decay(profile, _THRESHOLDS)
+    assert result is not None
+    assert result.type == "decay"
+    assert "fitness goal" in result.message
+    assert "61 days" in result.message
+    assert "build muscle" in result.message
+
+
+def test_check_decay_null_field_not_stale() -> None:
+    """Null fields are never returned as stale (they have no timestamp)."""
+    # Profile with no fields set → all None → no timestamps
+    profile = UserProfile()
+    result = check_decay(profile, _THRESHOLDS)
+    assert result is None
+
+
+def test_check_decay_most_overdue_field_selected() -> None:
+    """When multiple fields are stale, the most overdue (largest overage) is returned."""
+    # fitness_goal: 61 days old, threshold 60 → overage 1
+    # fitness_level: 100 days old, threshold 90 → overage 10  ← most overdue
+    profile = _make_profile(fitness_goal=61, fitness_level=100)
+    result = check_decay(profile, _THRESHOLDS)
+    assert result is not None
+    assert "fitness level" in result.message
+
+
+def test_check_decay_thresholds_configurable() -> None:
+    """Thresholds are read from the passed dict; custom threshold respected."""
+    profile = _make_profile(fitness_goal=30)
+    # With a threshold of 20 days for "goals", 30 days is stale
+    result = check_decay(profile, {"goals": 20})
+    assert result is not None
+    assert "fitness goal" in result.message
+
+    # With threshold of 60 days, 30 days is fresh
+    result_fresh = check_decay(profile, {"goals": 60})
+    assert result_fresh is None


### PR DESCRIPTION
## Issue

Closes #28

## What this PR does

Implements `check_decay(profile, thresholds)` in `profile/decay.py`; returns the most-overdue stale field's reconfirmation prompt. Replaces the inline decay logic in `session_start.py` with a call to this function.

## Acceptance criteria

- [x] `check_decay(profile: UserProfile, thresholds: dict) -> DecayPrompt | None` in `src/weles/profile/decay.py`
- [x] Decay thresholds mapping: goals→60d, fitness_level→90d, dietary_approach→90d, body_metrics→180d, taste_lifestyle→365d (configurable via passed `thresholds` dict)
- [x] Only non-null fields with a recorded timestamp are evaluated
- [x] Returns the most-overdue field's prompt (highest `age_days - threshold_days`)
- [x] Prompt: `"Your {field_label} was last set {X} days ago as '{value}'. Still accurate?"`
- [x] `_step2_decay_check` in `session_start.py` delegates to `check_decay`

## Tests

- [x] All tests specified in the issue are present (`tests/unit/test_decay.py`, 5 tests)
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` updated (no endpoint changes)
- [ ] `docs/architecture.md` updated (no structural changes)

## Notes

Return type is `DecayPrompt` (defined in `decay.py`) rather than `SessionStartPrompt` (defined in `session_start.py`) to avoid a circular import between `profile/` and `api/`. `_step2_decay_check` wraps the result in `SessionStartPrompt` before returning.