### PR TITLE
feat: #29 explicit confidence calibration

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `tool_result` blocks now appear before `text` blocks in user messages following a tool-use turn; previous ordering caused `BadRequestError` from the Anthropic API (#23)
 
 ### v0.6 — Signal Quality
-<!-- Issues #29–31 -->
+
+#### Added
+- `research.md` updated with explicit confidence calibration: responses must open with `[strong consensus]`, `[divided community]`, or `[thin data]`; each label defined with criteria (#29)
+- `[thin data]` format specified; minority opinion, data age, and discontinued product flags required (#29)
+- `scripts/eval_confidence.py`: runs 5 scenario queries for manual confidence label review; not a CI gate (#29)
 
 ### v1.0 — Distribution
 <!-- Issue #32 -->

--- a/scripts/eval_confidence.py
+++ b/scripts/eval_confidence.py
@@ -1,1 +1,103 @@
-# Confidence calibration evaluation script — implemented in later issues
+#!/usr/bin/env python3
+"""
+Confidence calibration evaluation script.
+Runs 5 queries targeting different signal-strength scenarios against live Claude
+and prints results for manual review of confidence label usage.
+
+Requires: ANTHROPIC_API_KEY set in env. TAVILY_API_KEY optional.
+Not a CI test — run manually for qualitative review.
+
+Usage:
+    uv run python scripts/eval_confidence.py
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# Ensure src/ is on the path when run from the repo root
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+QUERIES = [
+    # Expected: [thin data] — very niche, little community discussion
+    ("shopping", "What do people think of the Bellroy Venture Ready Pack backpack?"),
+    # Expected: [strong consensus] — popular, well-documented product
+    ("shopping", "What do long-term owners say about the Benchmade Bugout knife?"),
+    # Expected: [divided community] — genuine disagreement in running community
+    ("fitness", "Is running in Hokas better or worse than minimalist shoes for injury prevention?"),
+    # Expected: [thin data] or data age flag — product is old/discontinued
+    ("shopping", "What do people say about the Vibram FiveFingers Bikila?"),
+    # Expected: [thin data] — niche category with sparse community data
+    ("diet", "What supplements do people recommend for improving sleep quality in elite athletes?"),
+]
+
+_LABELS = ["[strong consensus]", "[divided community]", "[thin data]"]
+
+
+async def run_query(mode: str, query: str) -> None:
+    from weles.agent.client import get_client
+    from weles.agent.dispatch import ToolRegistry
+    from weles.agent.prompts import build_system_prompt
+    from weles.agent.stream import (
+        DoneEvent,
+        TextDeltaEvent,
+        ToolEndEvent,
+        ToolErrorEvent,
+        ToolStartEvent,
+        stream_response,
+    )
+    from weles.tools.reddit import SEARCH_REDDIT_SCHEMA, search_reddit_handler
+
+    client = get_client()
+    system = build_system_prompt(mode)
+    registry = ToolRegistry(max_calls=6)
+    registry.register("search_reddit", search_reddit_handler, SEARCH_REDDIT_SCHEMA)
+
+    if os.getenv("TAVILY_API_KEY"):
+        from weles.tools.web import SEARCH_WEB_SCHEMA, search_web_handler
+
+        registry.register("search_web", search_web_handler, SEARCH_WEB_SCHEMA)
+
+    messages = [{"role": "user", "content": query}]
+
+    print(f"\n{'=' * 70}")
+    print(f"Mode: {mode}")
+    print(f"Query: {query}")
+    print("=" * 70)
+
+    full_text: list[str] = []
+
+    async for event in stream_response(
+        client, messages, registry.get_tool_schemas(), system, registry
+    ):
+        if isinstance(event, TextDeltaEvent):
+            print(event.text, end="", flush=True)
+            full_text.append(event.text)
+        elif isinstance(event, ToolStartEvent):
+            print(f"\n[TOOL: {event.description}]", flush=True)
+        elif isinstance(event, ToolEndEvent):
+            print(f"[TOOL DONE: {event.result_summary}]", flush=True)
+        elif isinstance(event, ToolErrorEvent):
+            print(f"[TOOL ERROR: {event.tool} — {event.error}]", flush=True)
+        elif isinstance(event, DoneEvent):
+            print("\n[DONE]", flush=True)
+
+    response = "".join(full_text)
+    found = [label for label in _LABELS if label in response]
+    if found:
+        print(f"\n  ✓ Confidence label used: {found[0]}")
+    else:
+        print("\n  ✗ WARNING: No confidence label found in response")
+
+
+async def main() -> None:
+    print("Confidence calibration eval — 5 scenarios")
+    print("Labels to look for: [strong consensus] | [divided community] | [thin data]")
+    for mode, query in QUERIES:
+        await run_query(mode, query)
+    print("\n\nDone. Review each response for correct label placement and reasoning quality.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/weles/prompts/research.md
+++ b/src/weles/prompts/research.md
@@ -11,11 +11,20 @@ When interpreting search results, each result carries a `credibility` field (`hi
 ## Synthesis guidelines
 
 [Research guidance]
-- Open with signal strength: [strong consensus] / [divided community] / [thin data]
-- Use [thin data] when fewer than 3 relevant posts found across all searches, or all searches failed
-- Surface dissenting views when a vocal minority exists
-- Flag data older than 3 years: "Note: most discussion on this dates to [year]."
-- Flag discontinued products explicitly
-- Never use manufacturer language, spec-sheet comparisons, or affiliate superlatives
+
+Open every research-backed response with exactly one signal strength label:
+
+**[strong consensus]** — Recurring agreement across ≥ 3 high-credibility posts from ≥ 2 different subreddits. Use this when the community position is clear and consistent.
+
+**[divided community]** — Meaningful disagreement between credible sources; both sides must be surfaced with their subreddit labels (e.g. "r/running prefers X; r/ultramarathon prefers Y"). Do not pick a side unless the user's profile provides clear directional preference.
+
+**[thin data]** — Fewer than 3 relevant posts found across all searches, or all searches failed, or only low-credibility results available. Format: "Community discussion on {topic} is sparse. Available signals: {summary}. Treat as a starting point, not consensus."
+
+Additional rules:
+- Minority opinion explicitly named: "A minority of r/X users report…"
+- Data age flagged when all top results are > 3 years old: "Note: most community discussion on this dates to [year]."
+- Discontinued products flagged explicitly: "Note: [product] appears discontinued."
+- Heavily discount `low` and `flagged` credibility results; treat as weak signal only.
+- If the result set includes `"batch_flag": "coordinated_positivity"`, mention the possibility of astroturfing or coordinated promotion.
+- Never use manufacturer language, spec-sheet comparisons, or affiliate superlatives.
 - Show reasoning: not "buy X" but "Long-term owners prefer X because Y. Common failure point: Z."
-- When communities disagree, present both sides labelled by source — do not pick a side unless the user's profile provides clear directional preference

--- a/tests/unit/test_research_prompt.py
+++ b/tests/unit/test_research_prompt.py
@@ -1,0 +1,22 @@
+"""Unit tests for research.md confidence calibration labels (issue #29)."""
+
+from weles.utils.paths import resource_path
+
+
+def _research_md() -> str:
+    return resource_path("src/weles/prompts/research.md").read_text(encoding="utf-8")
+
+
+def test_research_md_contains_strong_consensus() -> None:
+    """research.md contains the [strong consensus] label."""
+    assert "[strong consensus]" in _research_md()
+
+
+def test_research_md_contains_divided_community() -> None:
+    """research.md contains the [divided community] label."""
+    assert "[divided community]" in _research_md()
+
+
+def test_research_md_contains_thin_data() -> None:
+    """research.md contains the [thin data] label."""
+    assert "[thin data]" in _research_md()


### PR DESCRIPTION
## Issue

Closes #29

## What this PR does

Updates `research.md` with explicit confidence calibration rules: responses must open with one of `[strong consensus]`, `[divided community]`, or `[thin data]`, each with defined criteria. Adds a manual eval script for 5 scenario queries.

## Acceptance criteria

- [x] `research.md` requires opening with exactly one of `[strong consensus]` / `[divided community]` / `[thin data]`
- [x] `[strong consensus]` criteria: ≥3 high-credibility posts from ≥2 subreddits
- [x] `[divided community]` criteria: meaningful disagreement, both sides surfaced with subreddit labels
- [x] `[thin data]` criteria: <3 relevant posts, all searches failed, or only low-credibility results; includes prescribed format
- [x] Minority opinion naming rule: "A minority of r/X users report…"
- [x] Data age flag: "Note: most community discussion on this dates to [year]."
- [x] Discontinued product flag: "Note: [product] appears discontinued."
- [x] `scripts/eval_confidence.py`: 5 queries covering obscure, popular, divided, old, and niche scenarios

## Tests

- [x] `tests/unit/test_research_prompt.py`: 3 tests — presence of all three labels in research.md
- [x] `make lint` passes (src/ and tests/)
- [x] `make test` passes

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]` v0.6 section
- [ ] `docs/api.md` — no endpoint changes
- [ ] `docs/architecture.md` — no structural changes