### PR TITLE
feat: #30 anti-bias and astroturfing heuristics

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `research.md` updated with explicit confidence calibration: responses must open with `[strong consensus]`, `[divided community]`, or `[thin data]`; each label defined with criteria (#29)
 - `[thin data]` format specified; minority opinion, data age, and discontinued product flags required (#29)
 - `scripts/eval_confidence.py`: runs 5 scenario queries for manual confidence label review; not a CI gate (#29)
+- `score_results` extended: tags `affiliate: True` on web results with affiliate URLs; geo-block filter tags `available: False` when domain is in `config/geo_blocks/{COUNTRY}.txt` and user country matches (#30)
+- Coordinated positivity detection extended: also fires when ≥3 low/flagged results all contain a shared astroturfing phrase (e.g. "exceeded my expectations") (#30)
+- `search_web_handler` and `search_reddit_handler` now call `score_results`; all credibility metadata present in results passed to Claude (#30)
 
 ### v1.0 — Distribution
 <!-- Issue #32 -->

--- a/config/geo_blocks/PL.txt
+++ b/config/geo_blocks/PL.txt
@@ -1,1 +1,7 @@
-# Poland domain blocklist — populated in later issues
+# Poland geo-block list — retailers not shipping to Poland
+# Add domain names only (no protocol, no www prefix)
+mediaexpert.pl
+morele.net
+oleole.pl
+bestbuy.com
+newegg.com

--- a/src/weles/prompts/research.md
+++ b/src/weles/prompts/research.md
@@ -2,7 +2,7 @@
 
 When calling `search_reddit`, pass the most specific subcategory that matches the user's query using the `subcategory` parameter — the server resolves it to the right subreddits. Available subcategories for the current mode are listed in your system context. If none fits, omit `subcategory` and the general list for this mode is used. If the user explicitly names a subreddit, pass it via `subreddits` instead.
 
-When interpreting search results, each result carries a `credibility` field (`high`, `medium`, `low`, or `flagged`).
+Search results are returned as `{"results": [...], "batch_flag": ...}`. Each item in `results` carries a `credibility` field (`high`, `medium`, `low`, or `flagged`). Web results may also carry `affiliate: true` (URL is commission-linked) and `available: false` (retailer does not ship to the user's country — exclude from synthesis).
 
 - Heavily discount `low` and `flagged` results. Treat them as weak signal only — do not base recommendations primarily on them.
 - If the result set includes `"batch_flag": "coordinated_positivity"`, mention the possibility of astroturfing or coordinated promotion to the user.

--- a/src/weles/research/credibility.py
+++ b/src/weles/research/credibility.py
@@ -1,8 +1,10 @@
 import re
+from collections.abc import Sequence
 from typing import Any, Literal, cast
 
 from weles.tools.reddit import RedditPost
 from weles.tools.web import WebResult
+from weles.utils.paths import resource_path
 
 CredibilityLabel = Literal["high", "medium", "low", "flagged"]
 
@@ -12,7 +14,18 @@ _OWNERSHIP_RE = re.compile(
 _SWITCHED_RE = re.compile(r"\bswitched?\s+(from|away\s+from)\b")
 _AFFILIATE_RE = re.compile(r"[?&](ref|aff|tag)=|/(go|out|recommends)/")
 
+_ASTROTURF_PHRASES = frozenset(
+    [
+        "exceeded my expectations",
+        "highly recommend",
+        "five stars",
+        "couldn't be happier",
+        "absolutely love it",
+    ]
+)
+
 _TIERS: list[CredibilityLabel] = ["low", "medium", "high"]
+_geo_block_cache: dict[str, set[str]] = {}
 
 
 def _promote(label: CredibilityLabel) -> CredibilityLabel:
@@ -57,6 +70,28 @@ def score_result(result: RedditPost | WebResult) -> CredibilityLabel:
     return _score_web(result)
 
 
+def _load_geo_block(country_code: str) -> set[str]:
+    """Load and cache the geo-block domain list for a country code.
+
+    Returns an empty set if no file exists for the country.
+    """
+    key = country_code.upper()
+    if key in _geo_block_cache:
+        return _geo_block_cache[key]
+    try:
+        path = resource_path(f"config/geo_blocks/{key}.txt")
+        domains: set[str] = set()
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                domains.add(line.lower())
+        _geo_block_cache[key] = domains
+        return domains
+    except OSError:
+        _geo_block_cache[key] = set()
+        return set()
+
+
 def _ngrams(text: str, n: int) -> set[tuple[str, ...]]:
     words = text.lower().split()
     if len(words) < n:
@@ -64,13 +99,39 @@ def _ngrams(text: str, n: int) -> set[tuple[str, ...]]:
     return {tuple(words[i : i + n]) for i in range(len(words) - n + 1)}
 
 
+def _has_astroturf_phrase(text: str) -> bool:
+    lower = text.lower()
+    return any(phrase in lower for phrase in _ASTROTURF_PHRASES)
+
+
 def score_results(
-    results: list[RedditPost | WebResult],
+    results: Sequence[RedditPost | WebResult],
+    country_code: str | None = None,
 ) -> dict[str, Any]:
-    """Score all results, appending `credibility` to each. Returns dict with `results`
-    and optional top-level `batch_flag` when coordinated positivity is detected."""
+    """Score all results, appending `credibility` to each.
+
+    Also tags:
+    - `affiliate: True` on web results with affiliate URLs
+    - `available: False` on web results whose domain is in the country's geo-block list
+      (only when `country_code` is provided and a geo-block file exists for that country)
+
+    Returns dict with `results` and optional top-level `batch_flag`
+    when coordinated positivity is detected.
+    """
     labels = [score_result(r) for r in results]
-    scored = [{**r, "credibility": label} for r, label in zip(results, labels, strict=True)]
+    geo_block: set[str] = _load_geo_block(country_code) if country_code else set()
+
+    scored: list[dict[str, Any]] = []
+    for result, label in zip(results, labels, strict=True):
+        scored_result: dict[str, Any] = {**result, "credibility": label}
+        is_web = "score" not in result
+        if is_web:
+            web = cast(WebResult, result)
+            if _AFFILIATE_RE.search(web["url"]):
+                scored_result["affiliate"] = True
+            if geo_block and web["domain"].lower() in geo_block:
+                scored_result["available"] = False
+        scored.append(scored_result)
 
     low_flagged_texts: list[str] = []
     for result, label in zip(results, labels, strict=True):
@@ -84,12 +145,17 @@ def score_results(
 
     batch_flag: str | None = None
     if len(low_flagged_texts) >= 3:
+        # Check n-gram overlap
         ngram_sets = [_ngrams(t, 4) for t in low_flagged_texts]
         counts: dict[tuple[str, ...], int] = {}
         for ns in ngram_sets:
             for gram in ns:
                 counts[gram] = counts.get(gram, 0) + 1
         if any(count >= 3 for count in counts.values()):
+            batch_flag = "coordinated_positivity"
+
+        # Check for shared astroturfing phrases across all low/flagged results
+        if batch_flag is None and all(_has_astroturf_phrase(t) for t in low_flagged_texts):
             batch_flag = "coordinated_positivity"
 
     out: dict[str, Any] = {"results": scored}

--- a/src/weles/tools/reddit.py
+++ b/src/weles/tools/reddit.py
@@ -193,6 +193,8 @@ SEARCH_REDDIT_SCHEMA: dict[str, Any] = {
 
 
 async def search_reddit_handler(tool_input: dict[str, Any]) -> ToolResult:
+    from weles.research.credibility import score_results
+
     posts = await search_reddit(
         query=tool_input["query"],
         subreddits=tool_input.get("subreddits"),
@@ -202,8 +204,9 @@ async def search_reddit_handler(tool_input: dict[str, Any]) -> ToolResult:
     )
     if not posts:
         return ToolResult(summary="No posts found.", data=[])
+    scored = score_results(posts)
     top_score = posts[0]["score"]
     return ToolResult(
-        summary=f"Found {len(posts)} posts (top score: {top_score})",
-        data=posts,
+        summary=f"Found {len(scored['results'])} posts (top score: {top_score})",
+        data=scored,
     )

--- a/src/weles/tools/web.py
+++ b/src/weles/tools/web.py
@@ -7,6 +7,17 @@ import httpx
 from weles.agent.dispatch import ToolResult
 from weles.utils.paths import resource_path
 
+
+def _get_user_country() -> str | None:
+    """Return the user's country from the profile, or None."""
+    try:
+        from weles.db.profile_repo import get_profile
+
+        return get_profile().country
+    except Exception:
+        return None
+
+
 _TAVILY_URL = "https://api.tavily.com/search"
 
 _community_domains: set[str] | None = None
@@ -117,13 +128,17 @@ SEARCH_WEB_SCHEMA: dict[str, Any] = {
 
 
 async def search_web_handler(tool_input: dict[str, Any]) -> ToolResult:
+    from weles.research.credibility import score_results
+
     results = await search_web(
         query=tool_input["query"],
         limit=tool_input.get("limit", 8),
     )
     if not results:
         return ToolResult(summary="No results found.", data=[])
+    country = _get_user_country()
+    scored = score_results(results, country_code=country)
     return ToolResult(
-        summary=f"Found {len(results)} results",
-        data=results,
+        summary=f"Found {len(scored['results'])} results",
+        data=scored,
     )

--- a/tests/unit/test_anti_bias.py
+++ b/tests/unit/test_anti_bias.py
@@ -1,0 +1,118 @@
+"""Unit tests for anti-bias and astroturfing heuristics (issue #30)."""
+
+from weles.research.credibility import score_results
+
+
+def _web_result(url: str, domain: str = "example.com", source_type: str = "unknown") -> dict:
+    return {
+        "title": "Test",
+        "url": url,
+        "snippet": "Some text.",
+        "domain": domain,
+        "source_type": source_type,
+    }
+
+
+def _reddit_post(text: str, score: int = 1) -> dict:
+    return {
+        "title": "Test post",
+        "url": "https://reddit.com/r/test/comments/abc",
+        "score": score,
+        "created_utc": 0.0,
+        "subreddit": "test",
+        "selftext_preview": text,
+        "top_comments": [],
+    }
+
+
+def test_affiliate_ref_param_flagged_with_metadata() -> None:
+    """`?ref=` in URL → credibility 'flagged' and affiliate: True."""
+    result = _web_result("https://shop.example.com/product?ref=partner123")
+    out = score_results([result])
+    scored = out["results"][0]
+    assert scored["credibility"] == "flagged"
+    assert scored.get("affiliate") is True
+
+
+def test_affiliate_go_path_flagged() -> None:
+    """`/go/` in URL path → credibility 'flagged'."""
+    result = _web_result("https://review.example.com/go/some-product")
+    out = score_results([result])
+    scored = out["results"][0]
+    assert scored["credibility"] == "flagged"
+
+
+def test_non_affiliate_url_unaffected() -> None:
+    """Unknown URL with no affiliate params → no 'affiliate' tag, credibility 'medium'."""
+    result = _web_result("https://example.com/review")
+    out = score_results([result])
+    scored = out["results"][0]
+    assert scored["credibility"] == "medium"
+    assert "affiliate" not in scored
+
+
+def test_geo_block_tags_available_false(tmp_path, monkeypatch) -> None:
+    """Domain in PL.txt + country_code='PL' → available: False."""
+    import weles.research.credibility as cred_module
+
+    # Clear cache to avoid cross-test pollution
+    cred_module._geo_block_cache.clear()
+
+    # Point resource_path to a temp dir with a PL.txt file
+    geo_dir = tmp_path / "config" / "geo_blocks"
+    geo_dir.mkdir(parents=True)
+    (geo_dir / "PL.txt").write_text("bestbuy.com\nnewegg.com\n")
+
+    import weles.utils.paths as paths_module
+
+    original_resource_path = paths_module.resource_path
+
+    def patched_resource_path(rel: str):
+        candidate = tmp_path / rel
+        if candidate.exists():
+            return candidate
+        return original_resource_path(rel)
+
+    monkeypatch.setattr(paths_module, "resource_path", patched_resource_path)
+    monkeypatch.setattr(cred_module, "resource_path", patched_resource_path)
+
+    result = _web_result("https://bestbuy.com/product", domain="bestbuy.com")
+    out = score_results([result], country_code="PL")
+    scored = out["results"][0]
+    assert scored.get("available") is False
+
+
+def test_no_geo_block_file_no_available_tag(tmp_path, monkeypatch) -> None:
+    """If no geo_block file exists for the country, no 'available' tag applied."""
+    import weles.research.credibility as cred_module
+
+    cred_module._geo_block_cache.clear()
+
+    import weles.utils.paths as paths_module
+
+    original_resource_path = paths_module.resource_path
+
+    def patched_resource_path(rel: str):
+        # Never find config/geo_blocks/XX.txt
+        if "geo_blocks" in rel:
+            return tmp_path / rel
+        return original_resource_path(rel)
+
+    monkeypatch.setattr(paths_module, "resource_path", patched_resource_path)
+    monkeypatch.setattr(cred_module, "resource_path", patched_resource_path)
+
+    result = _web_result("https://bestbuy.com/product", domain="bestbuy.com")
+    out = score_results([result], country_code="XX")
+    scored = out["results"][0]
+    assert "available" not in scored
+
+
+def test_coordinated_positivity_via_shared_phrase() -> None:
+    """3 low-credibility results with shared phrase → coordinated_positivity."""
+    posts = [
+        _reddit_post("This product exceeded my expectations, great buy.", score=2),
+        _reddit_post("I was amazed — exceeded my expectations by a lot.", score=3),
+        _reddit_post("It totally exceeded my expectations, can't fault it.", score=1),
+    ]
+    out = score_results(posts)
+    assert out.get("batch_flag") == "coordinated_positivity"


### PR DESCRIPTION
## Issue

Closes #30

## What this PR does

Extends credibility scoring with affiliate tagging, geo-block filtering, and phrase-based astroturfing detection. Wires `score_results` into both search handlers so all metadata reaches Claude.

## Acceptance criteria

- [x] Affiliate URL detection: `?ref=`, `?aff=`, `?tag=`, `/go/`, `/out/`, `/recommends/` → `credibility: "flagged"` + `affiliate: True`
- [x] Geographic relevance filter: `config/geo_blocks/{COUNTRY}.txt` loaded; result domain in list → `available: False`; missing file → silently skipped
- [x] Coordinated positivity extended: also fires when all ≥3 low/flagged results contain a shared astroturfing phrase
- [x] All credibility metadata present in results passed to Claude (`score_results` wired into `search_web_handler` and `search_reddit_handler`)

## Tests

- [x] `tests/unit/test_anti_bias.py` — 6 tests covering all acceptance criteria
- [x] `make lint` passes
- [x] `make test` passes

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]` v0.6 section
- [ ] `docs/api.md` — no endpoint changes
- [ ] `docs/architecture.md` — no structural changes

## Notes

`_geo_block_cache` is a module-level dict; tests use `monkeypatch` to clear it and patch `resource_path`. `PL.txt` seeded with 5 sample domains (bestbuy.com, newegg.com, mediaexpert.pl, morele.net, oleole.pl).