### PR TITLE
feat: #31 Scoped proactive surfacing

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `score_results` extended: tags `affiliate: True` on web results with affiliate URLs; geo-block filter tags `available: False` when domain is in `config/geo_blocks/{COUNTRY}.txt` and user country matches (#30)
 - Coordinated positivity detection extended: also fires when ≥3 low/flagged results all contain a shared astroturfing phrase (e.g. "exceeded my expectations") (#30)
 - `search_web_handler` and `search_reddit_handler` now call `score_results`; all credibility metadata present in results passed to Claude (#30)
+- `run_proactive_checks()` added as step 5 of the session-start orchestrator: checks the 5 most recent bought/tried items for Reddit quality-issue discussion (score > 50, cached 24 h per item) and surfaces seasonal notices from `config/seasonal.toml` when the user has domain history (#31)
+- `config/seasonal.toml` populated with four seasonal entries (fitness/January–February, shopping/November–December, diet/June–August, lifestyle/March–April) (#31)
 
 ### v1.0 — Distribution
 <!-- Issue #32 -->

--- a/config/seasonal.toml
+++ b/config/seasonal.toml
@@ -1,1 +1,26 @@
-# Seasonal config — populated in later issues
+# Seasonal surfacing config.
+# Each entry is surfaced at session start when:
+#   - current month is in `months`
+#   - user has any history in `domain`
+#
+# months: 1 = January … 12 = December
+
+[[entries]]
+domain = "fitness"
+months = [1, 2]
+prompt = "New year is a common time to reassess training — want me to review your current programme?"
+
+[[entries]]
+domain = "shopping"
+months = [11, 12]
+prompt = "Black Friday / holiday season is coming up — worth checking if anything on your wishlist is on sale."
+
+[[entries]]
+domain = "diet"
+months = [6, 7, 8]
+prompt = "Summer is here — good time to revisit hydration and lighter meal approaches if that interests you."
+
+[[entries]]
+domain = "lifestyle"
+months = [3, 4]
+prompt = "Spring is a natural reset point — let me know if you want ideas for any lifestyle changes."

--- a/src/weles/api/routers/sessions.py
+++ b/src/weles/api/routers/sessions.py
@@ -46,7 +46,7 @@ async def create_session() -> dict[str, Any]:
         (session_id, now),
     )
     conn.commit()
-    checks = run_session_start_checks(conn)
+    checks = await run_session_start_checks(conn)
     return {
         "id": session_id,
         "title": None,

--- a/src/weles/api/session_start.py
+++ b/src/weles/api/session_start.py
@@ -5,15 +5,21 @@ Runs all session-start checks in order; returns at most one user-facing prompt.
 
 from __future__ import annotations
 
+import logging
 import sqlite3
+import tomllib
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from weles.db.connection import get_db
 from weles.db.profile_repo import get_profile, update_preference
-from weles.db.settings_repo import get_setting
+from weles.db.settings_repo import get_setting, set_setting
 from weles.profile.decay import check_decay
+from weles.profile.models import UserProfile
+from weles.utils.paths import resource_path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -130,7 +136,102 @@ def _step4_checkin_check(conn: sqlite3.Connection) -> SessionStartPrompt | None:
     return check_check_in(conn)
 
 
-def run_session_start_checks(conn: sqlite3.Connection | None = None) -> SessionStartResult:
+async def run_proactive_checks(
+    conn: sqlite3.Connection,
+    profile: UserProfile,  # noqa: ARG001 — reserved for future profile-aware filtering
+) -> list[str]:
+    """Return QC alerts and seasonal notices for the current session.
+
+    Returns an empty list immediately if the ``proactive_surfacing`` setting is
+    ``"false"``.  Otherwise:
+
+    * Checks the 5 most recent *bought* / *tried* history items for recent
+      community quality-issue discussion on Reddit (cached 24 h per item).
+    * Surfaces seasonal notices from ``config/seasonal.toml`` when the current
+      month matches and the user has any history in the relevant domain.
+    """
+    from weles.tools.reddit import search_reddit
+
+    if get_setting("proactive_surfacing") == "false":
+        return []
+
+    notices: list[str] = []
+    now = datetime.utcnow()
+    _24h_ago = now - timedelta(hours=24)
+
+    # --- QC monitoring ---
+    rows = conn.execute(
+        "SELECT id, item_name FROM history"
+        " WHERE status IN ('bought', 'tried')"
+        " ORDER BY created_at DESC LIMIT 5"
+    ).fetchall()
+
+    for row in rows:
+        item_id: str = row["id"]
+        item_name: str = row["item_name"]
+        cache_key = f"qc_cache_{item_id}"
+
+        cached = get_setting(cache_key)
+        if cached and isinstance(cached, dict):
+            cached_ts_str = cached.get("timestamp")
+            if cached_ts_str:
+                try:
+                    cached_ts = datetime.fromisoformat(cached_ts_str)
+                    if cached_ts >= _24h_ago:
+                        continue
+                except ValueError:
+                    pass
+
+        try:
+            posts = await search_reddit(
+                query=f"{item_name} quality issue OR defect OR recall",
+                time_filter="month",
+                limit=5,
+            )
+        except Exception:
+            logger.warning("QC search failed for %s", item_name)
+            continue
+
+        found = False
+        for post in posts:
+            if post["score"] > 50:
+                found = True
+                url = post["url"]
+                notices.append(
+                    f"Recent community discussion about quality issues with {item_name}: {url}"
+                )
+                break
+
+        set_setting(cache_key, {"timestamp": now.isoformat(), "found": found})
+
+    # --- Seasonal surfacing ---
+    seasonal_path = resource_path("config/seasonal.toml")
+    try:
+        with open(seasonal_path, "rb") as fh:
+            seasonal_data = tomllib.load(fh)
+    except (FileNotFoundError, OSError):
+        return notices
+
+    current_month = now.month
+    for entry in seasonal_data.get("entries", []):
+        months: list[int] = entry.get("months", [])
+        if current_month not in months:
+            continue
+        domain: str = entry.get("domain", "")
+        if not domain:
+            continue
+        has_history = conn.execute(
+            "SELECT 1 FROM history WHERE domain = ? LIMIT 1", (domain,)
+        ).fetchone()
+        if has_history:
+            notices.append(entry["prompt"])
+
+    return notices
+
+
+async def run_session_start_checks(
+    conn: sqlite3.Connection | None = None,
+) -> SessionStartResult:
     """Run all session-start checks in order; return at most one user-facing prompt.
 
     Execution order:
@@ -138,7 +239,7 @@ def run_session_start_checks(conn: sqlite3.Connection | None = None) -> SessionS
     2. Profile decay check
     3. Follow-up check (skipped if step 2 produced a prompt)
     4. Check-in check (skipped if step 2 or 3 produced a prompt)
-    5. QC / proactive surfacing (notices only; independent of prompt — implemented in #31)
+    5. QC / proactive surfacing (notices only; independent of prompt)
     """
     if conn is None:
         conn = get_db()
@@ -155,7 +256,7 @@ def run_session_start_checks(conn: sqlite3.Connection | None = None) -> SessionS
     if result.prompt is None:
         result.prompt = _step4_checkin_check(conn)
 
-    # Step 5: QC / proactive surfacing (notices only) — implemented in #31
-    # result.notices = _step5_qc_notices(conn)
+    profile = get_profile()
+    result.notices = await run_proactive_checks(conn, profile)
 
     return result

--- a/tests/unit/test_preferences.py
+++ b/tests/unit/test_preferences.py
@@ -42,16 +42,18 @@ def test_update_preference_appears_in_profile_block(tmp_db) -> None:
     assert "No minimalist" in block
 
 
-def test_passive_detection_writes_preference_on_three_skips(tmp_db) -> None:
+async def test_passive_detection_writes_preference_on_three_skips(tmp_db, mocker) -> None:
     """Passive detection writes one preference when ≥3 items are skipped in same domain+category."""
     from weles.api.session_start import run_session_start_checks
     from weles.db.connection import get_db
+
+    mocker.patch("weles.api.session_start.run_proactive_checks", return_value=[])
 
     conn = get_db()
     for name in ("Boot A", "Boot B", "Boot C"):
         _insert_history(conn, name, "shopping", "footwear", "skipped")
 
-    run_session_start_checks(conn)
+    await run_session_start_checks(conn)
 
     row = conn.execute("SELECT * FROM preferences WHERE dimension = 'shopping.footwear'").fetchone()
     assert row is not None
@@ -59,16 +61,18 @@ def test_passive_detection_writes_preference_on_three_skips(tmp_db) -> None:
     assert "footwear" in row["value"]
 
 
-def test_passive_detection_does_not_write_on_two_skips(tmp_db) -> None:
+async def test_passive_detection_does_not_write_on_two_skips(tmp_db, mocker) -> None:
     """Passive detection writes nothing when fewer than 3 items are skipped."""
     from weles.api.session_start import run_session_start_checks
     from weles.db.connection import get_db
+
+    mocker.patch("weles.api.session_start.run_proactive_checks", return_value=[])
 
     conn = get_db()
     for name in ("Boot A", "Boot B"):
         _insert_history(conn, name, "shopping", "footwear", "skipped")
 
-    run_session_start_checks(conn)
+    await run_session_start_checks(conn)
 
     row = conn.execute("SELECT * FROM preferences WHERE dimension = 'shopping.footwear'").fetchone()
     assert row is None

--- a/tests/unit/test_proactive.py
+++ b/tests/unit/test_proactive.py
@@ -1,0 +1,237 @@
+"""Unit tests for run_proactive_checks (issue #31)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+from weles.api.session_start import run_proactive_checks
+from weles.profile.models import UserProfile
+
+
+def _insert_history(
+    conn,
+    item_name: str,
+    domain: str,
+    status: str,
+    item_id: str | None = None,
+) -> str:
+    iid = item_id or str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO history (id, item_name, category, domain, status, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        (iid, item_name, "gear", domain, status, datetime.utcnow()),
+    )
+    conn.commit()
+    return iid
+
+
+def _empty_profile() -> UserProfile:
+    return UserProfile()
+
+
+# ---------------------------------------------------------------------------
+# proactive_surfacing="false" guard
+# ---------------------------------------------------------------------------
+
+
+async def test_proactive_disabled_returns_empty(tmp_db) -> None:
+    """Returns [] immediately when proactive_surfacing is 'false'."""
+    from weles.db.connection import get_db
+    from weles.db.settings_repo import set_setting
+
+    conn = get_db()
+    set_setting("proactive_surfacing", "false")
+    _insert_history(conn, "Garmin Watch", "shopping", "bought")
+
+    result = await run_proactive_checks(conn, _empty_profile())
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# QC cache behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_qc_cache_hit_skips_search(tmp_db, mocker) -> None:
+    """When a fresh cache entry exists (< 24 h), search_reddit is not called."""
+    from weles.db.connection import get_db
+    from weles.db.settings_repo import set_setting
+
+    mock_search = mocker.patch("weles.tools.reddit.search_reddit", return_value=[])
+
+    conn = get_db()
+    iid = _insert_history(conn, "Merino Wool Tee", "shopping", "bought")
+    # Write a cache entry timestamped 1 hour ago (within 24 h window).
+    recent_ts = (datetime.utcnow() - timedelta(hours=1)).isoformat()
+    set_setting(f"qc_cache_{iid}", {"timestamp": recent_ts, "found": False})
+
+    await run_proactive_checks(conn, _empty_profile())
+
+    mock_search.assert_not_called()
+
+
+async def test_qc_cache_miss_calls_search(tmp_db, mocker) -> None:
+    """When no cache entry exists, search_reddit is called for the item."""
+    from weles.db.connection import get_db
+
+    mock_search = mocker.patch("weles.tools.reddit.search_reddit", return_value=[])
+
+    conn = get_db()
+    _insert_history(conn, "Trail Shoes", "shopping", "bought")
+
+    await run_proactive_checks(conn, _empty_profile())
+
+    mock_search.assert_called_once()
+    call_kwargs = mock_search.call_args
+    assert "Trail Shoes" in call_kwargs.kwargs.get("query", "") or "Trail Shoes" in str(
+        call_kwargs.args
+    )
+
+
+async def test_qc_high_score_post_adds_notice(tmp_db, mocker) -> None:
+    """A post with score > 50 triggers a QC notice."""
+    from weles.db.connection import get_db
+
+    fake_post = {
+        "title": "Quality issues with Trail Shoes",
+        "url": "https://reddit.com/r/running/comments/abc",
+        "score": 99,
+        "created_utc": 0.0,
+        "subreddit": "running",
+        "selftext_preview": "",
+        "top_comments": [],
+    }
+    mocker.patch("weles.tools.reddit.search_reddit", return_value=[fake_post])
+
+    conn = get_db()
+    _insert_history(conn, "Trail Shoes", "shopping", "bought")
+
+    notices = await run_proactive_checks(conn, _empty_profile())
+
+    assert len(notices) >= 1
+    assert "Trail Shoes" in notices[0]
+    assert "https://reddit.com/r/running/comments/abc" in notices[0]
+
+
+async def test_qc_low_score_post_no_notice(tmp_db, mocker) -> None:
+    """A post with score ≤ 50 does not trigger a notice."""
+    from weles.db.connection import get_db
+
+    fake_post = {
+        "title": "Minor issue with Trail Shoes",
+        "url": "https://reddit.com/r/running/comments/xyz",
+        "score": 10,
+        "created_utc": 0.0,
+        "subreddit": "running",
+        "selftext_preview": "",
+        "top_comments": [],
+    }
+    mocker.patch("weles.tools.reddit.search_reddit", return_value=[fake_post])
+
+    conn = get_db()
+    _insert_history(conn, "Trail Shoes", "shopping", "bought")
+
+    notices = await run_proactive_checks(conn, _empty_profile())
+
+    assert notices == []
+
+
+async def test_qc_only_first_5_items_checked(tmp_db, mocker) -> None:
+    """Only the 5 most recent bought/tried items are checked."""
+    from weles.db.connection import get_db
+
+    mock_search = mocker.patch("weles.tools.reddit.search_reddit", return_value=[])
+
+    conn = get_db()
+    for i in range(7):
+        _insert_history(conn, f"Item {i}", "shopping", "bought")
+
+    await run_proactive_checks(conn, _empty_profile())
+
+    assert mock_search.call_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Seasonal surfacing
+# ---------------------------------------------------------------------------
+
+
+async def test_seasonal_match_with_domain_history_adds_notice(tmp_db, mocker) -> None:
+    """Seasonal entry for current month + user has domain history → notice returned."""
+    from weles.db.connection import get_db
+
+    mocker.patch("weles.tools.reddit.search_reddit", return_value=[])
+
+    current_month = datetime.utcnow().month
+    fake_seasonal = {
+        "entries": [
+            {
+                "domain": "fitness",
+                "months": [current_month],
+                "prompt": "Time to review your training plan.",
+            }
+        ]
+    }
+    mocker.patch("weles.api.session_start.tomllib.load", return_value=fake_seasonal)  # type: ignore[attr-defined]
+
+    conn = get_db()
+    _insert_history(conn, "Barbell", "fitness", "bought")
+
+    notices = await run_proactive_checks(conn, _empty_profile())
+
+    assert "Time to review your training plan." in notices
+
+
+async def test_seasonal_match_without_domain_history_no_notice(tmp_db, mocker) -> None:
+    """Seasonal entry for current month + user has no domain history → no notice."""
+    from weles.db.connection import get_db
+
+    mocker.patch("weles.tools.reddit.search_reddit", return_value=[])
+
+    current_month = datetime.utcnow().month
+    fake_seasonal = {
+        "entries": [
+            {
+                "domain": "fitness",
+                "months": [current_month],
+                "prompt": "Time to review your training plan.",
+            }
+        ]
+    }
+    mocker.patch("weles.api.session_start.tomllib.load", return_value=fake_seasonal)  # type: ignore[attr-defined]
+
+    conn = get_db()
+    # Insert history in a *different* domain
+    _insert_history(conn, "Chicken Breast", "diet", "bought")
+
+    notices = await run_proactive_checks(conn, _empty_profile())
+
+    assert "Time to review your training plan." not in notices
+
+
+async def test_seasonal_wrong_month_no_notice(tmp_db, mocker) -> None:
+    """Seasonal entry for a different month produces no notice."""
+    from weles.db.connection import get_db
+
+    mocker.patch("weles.tools.reddit.search_reddit", return_value=[])
+
+    current_month = datetime.utcnow().month
+    other_month = (current_month % 12) + 1  # always a different month
+    fake_seasonal = {
+        "entries": [
+            {
+                "domain": "fitness",
+                "months": [other_month],
+                "prompt": "This should not appear.",
+            }
+        ]
+    }
+    mocker.patch("weles.api.session_start.tomllib.load", return_value=fake_seasonal)  # type: ignore[attr-defined]
+
+    conn = get_db()
+    _insert_history(conn, "Barbell", "fitness", "bought")
+
+    notices = await run_proactive_checks(conn, _empty_profile())
+
+    assert "This should not appear." not in notices

--- a/tests/unit/test_session_start.py
+++ b/tests/unit/test_session_start.py
@@ -54,19 +54,21 @@ def _set_profile_field_with_timestamp(conn, field_name: str, value: str, days_ag
     conn.commit()
 
 
-def test_no_due_items_returns_empty(tmp_db) -> None:
+async def test_no_due_items_returns_empty(tmp_db) -> None:
     """With no due items, returns {prompt: None, notices: []}."""
     from weles.db.connection import get_db
 
     conn = get_db()
-    result = run_session_start_checks(conn)
+    result = await run_session_start_checks(conn)
     assert result.prompt is None
     assert result.notices == []
 
 
-def test_decay_wins_over_followup(tmp_db) -> None:
+async def test_decay_wins_over_followup(tmp_db, mocker) -> None:
     """With decay due AND follow-up due, decay prompt is returned (decay wins)."""
     from weles.db.connection import get_db
+
+    mocker.patch("weles.api.session_start.run_proactive_checks", return_value=[])
 
     conn = get_db()
     # Fitness level set 200 days ago (threshold = 90 days)
@@ -77,14 +79,16 @@ def test_decay_wins_over_followup(tmp_db) -> None:
         conn, "Running Shoes", "shopping", "footwear", "recommended", follow_up_due_at=past
     )
 
-    result = run_session_start_checks(conn)
+    result = await run_session_start_checks(conn)
     assert result.prompt is not None
     assert result.prompt.type == "decay"
 
 
-def test_followup_wins_over_checkin(tmp_db) -> None:
+async def test_followup_wins_over_checkin(tmp_db, mocker) -> None:
     """With follow-up due AND check-in due, follow-up prompt is returned."""
     from weles.db.connection import get_db
+
+    mocker.patch("weles.api.session_start.run_proactive_checks", return_value=[])
 
     conn = get_db()
     past = datetime.utcnow() - timedelta(days=1)
@@ -93,33 +97,37 @@ def test_followup_wins_over_checkin(tmp_db) -> None:
     )
     _insert_history(conn, "GZCLP", "fitness", "program", "bought", check_in_due_at=past)
 
-    result = run_session_start_checks(conn)
+    result = await run_session_start_checks(conn)
     assert result.prompt is not None
     assert result.prompt.type == "follow_up"
 
 
-def test_checkin_when_only_due(tmp_db) -> None:
+async def test_checkin_when_only_due(tmp_db, mocker) -> None:
     """With only a check-in due, check-in prompt is returned."""
     from weles.db.connection import get_db
+
+    mocker.patch("weles.api.session_start.run_proactive_checks", return_value=[])
 
     conn = get_db()
     past = datetime.utcnow() - timedelta(days=1)
     _insert_history(conn, "Starting Strength", "fitness", "program", "bought", check_in_due_at=past)
 
-    result = run_session_start_checks(conn)
+    result = await run_session_start_checks(conn)
     assert result.prompt is not None
     assert result.prompt.type == "check_in"
 
 
-def test_passive_detection_writes_preference(tmp_db) -> None:
+async def test_passive_detection_writes_preference(tmp_db, mocker) -> None:
     """Passive detection writes a preference when ≥3 items skipped in the same category."""
     from weles.db.connection import get_db
+
+    mocker.patch("weles.api.session_start.run_proactive_checks", return_value=[])
 
     conn = get_db()
     for i in range(3):
         _insert_history(conn, f"Keto Bar {i}", "diet", "keto_snacks", "skipped")
 
-    run_session_start_checks(conn)
+    await run_session_start_checks(conn)
 
     pref = conn.execute(
         "SELECT * FROM preferences WHERE dimension = ?", ("diet.keto_snacks",)
@@ -129,13 +137,15 @@ def test_passive_detection_writes_preference(tmp_db) -> None:
     assert pref["source"] == "agent_inferred"
 
 
-def test_passive_detection_returns_no_prompt(tmp_db) -> None:
+async def test_passive_detection_returns_no_prompt(tmp_db, mocker) -> None:
     """Passive pattern detection does not produce a user-facing prompt."""
     from weles.db.connection import get_db
+
+    mocker.patch("weles.api.session_start.run_proactive_checks", return_value=[])
 
     conn = get_db()
     for i in range(3):
         _insert_history(conn, f"Supplement {i}", "diet", "supplements", "skipped")
 
-    result = run_session_start_checks(conn)
+    result = await run_session_start_checks(conn)
     assert result.prompt is None


### PR DESCRIPTION
## Summary

- Adds `run_proactive_checks(conn, profile) -> list[str]` as step 5 of the session-start orchestrator
- QC monitoring: checks the 5 most recent bought/tried history items for Reddit quality-issue posts (score > 50), with 24-hour per-item cache in the `settings` table
- Seasonal surfacing: loads `config/seasonal.toml`, surfaces notices when the current month matches and the user has domain history
- Both checks respect the `proactive_surfacing="false"` setting (immediate empty return)
- `run_session_start_checks` made async; router updated to `await` it; existing tests updated accordingly

## Acceptance criteria

- [x] `run_proactive_checks(db, profile) -> list[str]` in `session_start.py`; called as step 5 of orchestrator
- [x] QC monitoring: 5 most recent bought/tried items; 24 h cache per item in `settings`; score > 50 triggers notice
- [x] Seasonal surfacing: `config/seasonal.toml` entries matched by current month + domain history check
- [x] `proactive_surfacing="false"` → returns `[]` immediately
- [x] Notices included in `SessionStartResult.notices`

## Tests

- [x] `tests/unit/test_proactive.py` — 9 tests covering disabled guard, cache hit/miss, high/low score, 5-item cap, seasonal match/no-match/wrong-month
- [x] `tests/unit/test_session_start.py` — updated to async (6 tests)
- [x] `tests/unit/test_preferences.py` — passive detection tests updated to async (2 tests)
- All 157 tests pass

## Docs

- [x] `CHANGELOG.md` updated under v0.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)