### PR TITLE
feat: #32 System tray app, PyInstaller packaging, and Windows auto-start

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,43 @@
+name: Build Windows
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install PyInstaller
+        run: uv pip install pyinstaller
+
+      - name: Build
+        run: make package
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/Weles.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `config/seasonal.toml` populated with four seasonal entries (fitness/January–February, shopping/November–December, diet/June–August, lifestyle/March–April) (#31)
 
 ### v1.0 — Distribution
-<!-- Issue #32 -->
+
+#### Added
+- `src/weles/tray.py`: system tray entry point using `pystray`; starts the FastAPI server in a daemon thread, left-click opens browser, right-click menu has Open / Restart server / Quit (#32)
+- Auto-opens browser on first launch (`GET /health` → `first_run: true`); waits for server to be ready before opening (#32)
+- Port conflict detection at startup: tooltip shows "Port {port} already in use"; right-click menu adds "Change port" which persists `WELES_PORT` to `~/.weles/.env` (#32)
+- `weles.spec`: PyInstaller spec committed; bundles `frontend/dist`, `config`, `prompts`, `blocklist`, `assets` into a single `console=False` `Weles.exe` (#32)
+- `make package`: runs `npm run build` then `pyinstaller weles.spec --clean` → `dist/Weles.exe` (#32)
+- `make install`: copies `dist/Weles.exe` to `%LOCALAPPDATA%\Weles\Weles.exe` and creates a `.lnk` startup shortcut in the Windows Startup folder; no admin rights required (#32)
+- `make uninstall`: removes the startup shortcut; does not touch `~/.weles/` data (#32)
+- `.github/workflows/build-windows.yml`: triggers on `tags: v*.*.*`; runs `make package` on `windows-latest`; uploads `dist/Weles.exe` as a GitHub release asset (#32)
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,29 @@ lint:
 	uv run ruff check .
 	uv run mypy src/
 
+package:
+	cd frontend && npm run build
+	uv run pyinstaller weles.spec --clean
+
 install:
-	@echo "Implemented in #32"
+	powershell -NoProfile -ExecutionPolicy Bypass -Command "\
+		\$$src = 'dist\\Weles.exe'; \
+		\$$dst = \"\$$env:LOCALAPPDATA\\Weles\\Weles.exe\"; \
+		\$$startup = \"\$$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\Weles.lnk\"; \
+		New-Item -ItemType Directory -Force -Path (Split-Path \$$dst) | Out-Null; \
+		Copy-Item -Force \$$src \$$dst; \
+		\$$ws = New-Object -ComObject WScript.Shell; \
+		\$$lnk = \$$ws.CreateShortcut(\$$startup); \
+		\$$lnk.TargetPath = \$$dst; \
+		\$$lnk.WorkingDirectory = (Split-Path \$$dst); \
+		\$$lnk.Save(); \
+		Write-Host 'Installed Weles to' \$$dst; \
+		Write-Host 'Startup shortcut created at' \$$startup \
+	"
 
 uninstall:
-	@echo "Implemented in #32"
-
-package:
-	@echo "Implemented in #32"
+	powershell -NoProfile -ExecutionPolicy Bypass -Command "\
+		\$$startup = \"\$$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\Weles.lnk\"; \
+		if (Test-Path \$$startup) { Remove-Item -Force \$$startup; Write-Host 'Removed startup shortcut.' } \
+		else { Write-Host 'No startup shortcut found.' } \
+	"

--- a/src/weles/tray.py
+++ b/src/weles/tray.py
@@ -1,0 +1,194 @@
+"""Weles system tray entry point.
+
+Start the FastAPI server in a daemon thread and manage the system tray icon.
+This must be the PyInstaller entry point (``src/weles/tray.py``).
+"""
+
+# ruff: noqa: E402 — freeze_support() must be called before any other imports.
+from __future__ import annotations
+
+import multiprocessing
+
+multiprocessing.freeze_support()
+
+import os
+import socket
+import sys
+import threading
+import time
+import webbrowser
+from pathlib import Path
+
+import httpx
+import pystray
+import uvicorn
+from dotenv import load_dotenv, set_key
+from PIL import Image
+
+from weles.utils.paths import resource_path
+
+_WELES_DIR = Path.home() / ".weles"
+_ENV_FILE = _WELES_DIR / ".env"
+
+
+def _load_env() -> None:
+    load_dotenv(override=False)
+    if _ENV_FILE.exists():
+        load_dotenv(_ENV_FILE, override=False)
+
+
+def _get_port() -> int:
+    return int(os.getenv("WELES_PORT", "8000"))
+
+
+def _port_in_use(port: int) -> bool:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(0.1)
+    try:
+        sock.connect(("127.0.0.1", port))
+        sock.close()
+        return True
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
+
+def _open_browser(port: int) -> None:
+    webbrowser.open(f"http://localhost:{port}")
+
+
+def _wait_for_server(port: int, timeout: float = 15.0) -> bool:
+    """Poll GET /health until the server responds or timeout elapses."""
+    deadline = time.monotonic() + timeout
+    url = f"http://localhost:{port}/health"
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.get(url, timeout=1.0)
+            if resp.is_success:
+                return True
+        except httpx.RequestError:
+            pass
+        time.sleep(0.5)
+    return False
+
+
+def _is_first_run(port: int) -> bool:
+    try:
+        resp = httpx.get(f"http://localhost:{port}/health", timeout=2.0)
+        return bool(resp.json().get("first_run", False))
+    except Exception:
+        return False
+
+
+def _change_port(icon: pystray.Icon) -> None:
+    """Prompt the user to enter a new port and persist it to ~/.weles/.env."""
+    import tkinter as tk
+    from tkinter import simpledialog
+
+    root = tk.Tk()
+    root.withdraw()
+    new_port = simpledialog.askstring(
+        "Change port", "Enter new port number:", initialvalue=str(_get_port())
+    )
+    root.destroy()
+    if new_port and new_port.strip().isdigit():
+        _WELES_DIR.mkdir(parents=True, exist_ok=True)
+        if not _ENV_FILE.exists():
+            _ENV_FILE.touch()
+        set_key(str(_ENV_FILE), "WELES_PORT", new_port.strip())
+        os.environ["WELES_PORT"] = new_port.strip()
+        icon.title = f"Weles (restart to apply port {new_port.strip()})"
+
+
+def main() -> None:
+    _load_env()
+
+    port = _get_port()
+    port_conflict = _port_in_use(port)
+
+    icon_path = resource_path("assets/icon.ico")
+    image = Image.open(icon_path)
+
+    server: uvicorn.Server | None = None
+    server_thread: threading.Thread | None = None
+
+    if not port_conflict:
+        config = uvicorn.Config(
+            "weles.api.main:app",
+            host="127.0.0.1",
+            port=port,
+            log_level="info",
+        )
+        server = uvicorn.Server(config)
+        server_thread = threading.Thread(
+            target=server.run,
+            daemon=True,
+        )
+        server_thread.start()
+
+    def on_open(icon: pystray.Icon, item: pystray.MenuItem) -> None:  # noqa: ARG001
+        _open_browser(_get_port())
+
+    def on_restart(icon: pystray.Icon, item: pystray.MenuItem) -> None:  # noqa: ARG001
+        nonlocal server, server_thread
+        if server is not None:
+            server.should_exit = True
+            if server_thread is not None:
+                server_thread.join(timeout=5)
+        new_port = _get_port()
+        new_config = uvicorn.Config(
+            "weles.api.main:app",
+            host="127.0.0.1",
+            port=new_port,
+            log_level="info",
+        )
+        server = uvicorn.Server(new_config)
+        server_thread = threading.Thread(target=server.run, daemon=True)
+        server_thread.start()
+        icon.title = f"Weles (port {new_port})"
+
+    def on_quit(icon: pystray.Icon, item: pystray.MenuItem) -> None:  # noqa: ARG001
+        icon.stop()
+        if server is not None:
+            server.should_exit = True
+            if server_thread is not None:
+                server_thread.join(timeout=5)
+        sys.exit(0)
+
+    if port_conflict:
+        tooltip = f"Weles — Port {port} already in use"
+        menu_items: list[pystray.MenuItem] = [
+            pystray.MenuItem("Open", on_open, default=True),
+            pystray.MenuItem("Change port", lambda icon, item: _change_port(icon)),
+            pystray.MenuItem("Quit", on_quit),
+        ]
+    else:
+        tooltip = f"Weles (port {port})"
+        menu_items = [
+            pystray.MenuItem("Open", on_open, default=True),
+            pystray.MenuItem("Restart server", on_restart),
+            pystray.MenuItem("Quit", on_quit),
+        ]
+
+    icon = pystray.Icon(
+        name="Weles",
+        icon=image,
+        title=tooltip,
+        menu=pystray.Menu(*menu_items),
+    )
+
+    # On first launch, open the browser automatically after the server is ready.
+    if not port_conflict:
+
+        def _auto_open_if_first_run() -> None:
+            if _wait_for_server(port) and _is_first_run(port):
+                _open_browser(port)
+
+        threading.Thread(target=_auto_open_if_first_run, daemon=True).start()
+
+    icon.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/weles.spec
+++ b/weles.spec
@@ -1,0 +1,46 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+a = Analysis(
+    ["src/weles/tray.py"],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ("frontend/dist", "frontend/dist"),
+        ("config", "config"),
+        ("src/weles/prompts", "src/weles/prompts"),
+        ("blocklist", "blocklist"),
+        ("assets", "assets"),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="Weles",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    onefile=True,
+    icon="assets/icon.ico",
+)


### PR DESCRIPTION
## Summary

- `src/weles/tray.py`: pystray tray entry point, FastAPI server in daemon thread, left-click opens browser, right-click menu (Open / Restart server / Quit)
- First-launch auto-open: polls `GET /health` until server responds, then opens browser if `first_run: true`
- Port conflict: tooltip + "Change port" menu item that persists `WELES_PORT` to `~/.weles/.env`
- `weles.spec`: PyInstaller onefile spec (committed with `-f`, since `*.spec` is gitignored)
- `make package`, `make install`, `make uninstall` implemented
- `.github/workflows/build-windows.yml`: triggers on `v*.*.*` tags, uploads `Weles.exe` as release asset

## Acceptance criteria

- [x] `multiprocessing.freeze_support()` called before other imports
- [x] Server in `threading.Thread(daemon=True)`
- [x] Icon from `resource_path("assets/icon.ico")`
- [x] Left-click: opens browser at correct URL
- [x] First launch: browser opens automatically (via `/health` first_run check)
- [x] Port conflict: tooltip "Port {port} already in use"; "Change port" menu item writes to `~/.weles/.env`
- [x] Quit: `server.should_exit = True`; waits up to 5s; `sys.exit(0)`
- [x] `weles.spec` committed with correct `datas` entries
- [x] `make package` runs frontend build + pyinstaller
- [x] `make install`: copies exe, creates startup shortcut (no admin required)
- [x] `make uninstall`: removes startup shortcut; preserves `~/.weles/`
- [x] `build-windows.yml` workflow on `v*.*.*` tags

## Manual test checklist

- [ ] `Weles.exe` launches without terminal window
- [ ] Tray icon appears in Windows system tray
- [ ] Left-click opens browser at correct URL
- [ ] First launch opens browser automatically
- [ ] Quit from tray closes server cleanly
- [ ] Startup shortcut present after `make install`
- [ ] App starts on Windows login after install
- [ ] `~/.weles/` data intact after uninstall + reinstall

## Docs

- [x] `CHANGELOG.md` updated under v1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)