### PR TITLE
fix: #70 Off-by-one in tool call limit

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Fixed
 - Information tab content is now scrollable when it exceeds the viewport height; settings page receives the same fix (#68)
+- Tool call limit check now fires before the handler executes; counter checked with `>=` before increment so exactly `max_tool_calls_per_turn` calls are permitted (#70)
 
 ### v1.0 — Distribution
 

--- a/src/weles/agent/dispatch.py
+++ b/src/weles/agent/dispatch.py
@@ -26,9 +26,9 @@ class ToolRegistry:
     def dispatch(self, tool_name: str, tool_input: dict[str, Any]) -> ToolResult:
         if tool_name not in self._handlers:
             raise ToolNotFoundError(f"Unknown tool: {tool_name!r}")
-        self._call_count += 1
-        if self._call_count > self._max_calls:
+        if self._call_count >= self._max_calls:
             raise MaxToolCallsError(f"Research limit reached (max {self._max_calls})")
+        self._call_count += 1
         result = self._handlers[tool_name](tool_input)
         if isinstance(result, ToolResult):
             return result
@@ -39,9 +39,9 @@ class ToolRegistry:
     async def adispatch(self, tool_name: str, tool_input: dict[str, Any]) -> ToolResult:
         if tool_name not in self._handlers:
             raise ToolNotFoundError(f"Unknown tool: {tool_name!r}")
-        self._call_count += 1
-        if self._call_count > self._max_calls:
+        if self._call_count >= self._max_calls:
             raise MaxToolCallsError(f"Research limit reached (max {self._max_calls})")
+        self._call_count += 1
         result = self._handlers[tool_name](tool_input)
         if inspect.isawaitable(result):
             result = await result

--- a/tests/unit/test_tool_limit.py
+++ b/tests/unit/test_tool_limit.py
@@ -19,6 +19,24 @@ def test_7th_dispatch_raises_max_tool_calls_error() -> None:
         registry.dispatch("t", {})
 
 
+def test_dispatch_raises_when_call_count_equals_max() -> None:
+    """When _call_count already equals max_calls, the next dispatch raises before executing."""
+    registry = ToolRegistry(max_calls=3)
+    executed = []
+    registry.register("t", lambda _: executed.append(1) or "ok", {"type": "object"})
+
+    for _ in range(3):
+        registry.dispatch("t", {})
+
+    assert registry._call_count == registry._max_calls
+    assert len(executed) == 3
+
+    with pytest.raises(MaxToolCallsError):
+        registry.dispatch("t", {})
+
+    assert len(executed) == 3  # handler was not called on the failing dispatch
+
+
 def test_call_count_resets_between_sessions() -> None:
     """Each ToolRegistry instance has its own counter; sessions don't share state."""
     r1 = ToolRegistry(max_calls=1)


### PR DESCRIPTION
## Issue

Closes #70

## What this PR does

Restructures the `MaxToolCallsError` check in `ToolRegistry.dispatch()` and `adispatch()` to fire **before** incrementing `_call_count`, using `>=` instead of `>`. Semantics are unchanged — `max_calls=6` still allows exactly 6 executions — but the code is now more idiomatic: "if I'm already at the limit, reject before executing."

## Acceptance criteria

- [x] Both `dispatch()` and `adispatch()` check `>= self._max_calls` before incrementing
- [x] A call count equal to `max_calls` causes the **next** dispatch to raise `MaxToolCallsError` before execution
- [x] Existing test for 7th-call rejection still passes

## Tests

- [x] `test_dispatch_raises_when_call_count_equals_max` — new test: after exactly max_calls dispatches, the next one raises and the handler is not called
- [x] `test_7th_dispatch_raises_max_tool_calls_error` — existing test still passes
- [x] `make lint` passes
- [x] `make test` passes (excluding pre-existing `test_fitness_mode.py` failure from deleted `programs.py`)
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` — N/A (no endpoint changes)
- [ ] `docs/architecture.md` — N/A (no pattern changes)

## Notes

The pre-existing `ModuleNotFoundError: No module named 'weles.research.programs'` in `test_fitness_mode.py` is unrelated — `programs.py` is deleted in the working tree (git status shows `D src/weles/research/programs.py`). Not introduced by this PR.