### PR TITLE
fix: #71 Settings JSON safety — parse crash and write validation

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### Fixed
 - Information tab content is now scrollable when it exceeds the viewport height; settings page receives the same fix (#68)
 - Tool call limit check now fires before the handler executes; counter checked with `>=` before increment so exactly `max_tool_calls_per_turn` calls are permitted (#70)
+- `get_all_settings()` and `get_setting()` no longer crash on corrupt JSON in the settings table — bad rows are skipped with a warning (#71)
+- `set_setting()` validates value types for user-configurable keys; raises `ValueError` on invalid input, which the settings router converts to HTTP 422 (#71)
 
 ### v1.0 — Distribution
 

--- a/src/weles/api/routers/settings.py
+++ b/src/weles/api/routers/settings.py
@@ -18,5 +18,8 @@ async def patch_settings(body: dict[str, Any]) -> dict[str, Any]:
     if unknown:
         raise HTTPException(status_code=422, detail=f"Unknown settings keys: {sorted(unknown)}")
     for key, value in body.items():
-        set_setting(key, value)
+        try:
+            set_setting(key, value)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
     return get_all_settings()

--- a/src/weles/db/settings_repo.py
+++ b/src/weles/db/settings_repo.py
@@ -1,7 +1,10 @@
 import json
+import logging
 from typing import Any
 
 from weles.db.connection import get_db
+
+logger = logging.getLogger(__name__)
 
 _KNOWN_KEYS = {
     "follow_up_cadence",
@@ -10,11 +13,36 @@ _KNOWN_KEYS = {
     "max_tool_calls_per_turn",
 }
 
+# Validators for user-configurable keys only. Internal cache keys (e.g. qc_cache_*)
+# bypass these checks and are written directly via set_setting.
+_SETTING_VALIDATORS: dict[str, Any] = {
+    "max_tool_calls_per_turn": lambda v: (
+        isinstance(v, int) and not isinstance(v, bool) and 1 <= v <= 20
+    ),
+    "follow_up_cadence": lambda v: v in {"weekly", "monthly", "off"},
+    # stored and compared as string "true"/"false" by existing code
+    "proactive_surfacing": lambda v: isinstance(v, bool) or v in {"true", "false"},
+    "decay_thresholds": lambda v: isinstance(v, dict),
+}
+
+_SETTING_DESCRIPTIONS = {
+    "max_tool_calls_per_turn": "integer between 1 and 20",
+    "follow_up_cadence": "'weekly', 'monthly', or 'off'",
+    "proactive_surfacing": "boolean or 'true'/'false'",
+    "decay_thresholds": "dict",
+}
+
 
 def get_all_settings() -> dict[str, Any]:
     conn = get_db()
     rows = conn.execute("SELECT key, value FROM settings").fetchall()
-    return {row["key"]: json.loads(row["value"]) for row in rows}
+    result: dict[str, Any] = {}
+    for row in rows:
+        try:
+            result[row["key"]] = json.loads(row["value"])
+        except json.JSONDecodeError:
+            logger.warning("Skipping corrupt settings row key=%r", row["key"])
+    return result
 
 
 def get_setting(key: str) -> Any:
@@ -22,10 +50,24 @@ def get_setting(key: str) -> Any:
     row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
     if row is None:
         return None
-    return json.loads(row["value"])
+    try:
+        return json.loads(row["value"])
+    except json.JSONDecodeError:
+        logger.warning("Corrupt settings value for key=%r; returning None", key)
+        return None
 
 
 def set_setting(key: str, value: Any) -> None:
+    """Write a setting. Validates value type for user-configurable keys.
+
+    Raises ValueError if key is a known user setting with an invalid value.
+    Unknown keys (e.g. internal qc_cache_* entries) are written without validation.
+    """
+    if key in _KNOWN_KEYS:
+        validator = _SETTING_VALIDATORS[key]
+        if not validator(value):
+            description = _SETTING_DESCRIPTIONS[key]
+            raise ValueError(f"Invalid value for {key!r}: expected {description}, got {value!r}")
     conn = get_db()
     conn.execute(
         "INSERT INTO settings (key, value) VALUES (?, ?)"

--- a/tests/unit/test_settings_repo.py
+++ b/tests/unit/test_settings_repo.py
@@ -1,0 +1,85 @@
+import pytest
+
+from weles.db.settings_repo import get_all_settings, get_setting, set_setting
+
+
+def test_get_all_settings_skips_corrupt_row(tmp_db: object) -> None:
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    conn.execute("INSERT INTO settings (key, value) VALUES ('corrupt_key', 'not-json{{')")
+    conn.commit()
+
+    result = get_all_settings()
+    assert "corrupt_key" not in result
+    assert "max_tool_calls_per_turn" in result
+
+
+def test_get_setting_returns_none_on_corrupt_row(tmp_db: object) -> None:
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    conn.execute("INSERT INTO settings (key, value) VALUES ('corrupt_key', 'bad}')")
+    conn.commit()
+
+    assert get_setting("corrupt_key") is None
+
+
+def test_set_setting_max_tool_calls_valid(tmp_db: object) -> None:
+    set_setting("max_tool_calls_per_turn", 6)
+    assert get_setting("max_tool_calls_per_turn") == 6
+
+
+def test_set_setting_max_tool_calls_string_raises(tmp_db: object) -> None:
+    with pytest.raises(ValueError, match="max_tool_calls_per_turn"):
+        set_setting("max_tool_calls_per_turn", "abc")
+
+
+def test_set_setting_max_tool_calls_zero_raises(tmp_db: object) -> None:
+    with pytest.raises(ValueError, match="max_tool_calls_per_turn"):
+        set_setting("max_tool_calls_per_turn", 0)
+
+
+def test_set_setting_max_tool_calls_too_large_raises(tmp_db: object) -> None:
+    with pytest.raises(ValueError, match="max_tool_calls_per_turn"):
+        set_setting("max_tool_calls_per_turn", 21)
+
+
+def test_set_setting_max_tool_calls_bool_raises(tmp_db: object) -> None:
+    # bool is a subclass of int in Python; the validator must reject it explicitly
+    with pytest.raises(ValueError, match="max_tool_calls_per_turn"):
+        set_setting("max_tool_calls_per_turn", True)
+
+
+def test_set_setting_follow_up_cadence_valid(tmp_db: object) -> None:
+    for val in ("weekly", "monthly", "off"):
+        set_setting("follow_up_cadence", val)
+        assert get_setting("follow_up_cadence") == val
+
+
+def test_set_setting_follow_up_cadence_invalid_raises(tmp_db: object) -> None:
+    with pytest.raises(ValueError, match="follow_up_cadence"):
+        set_setting("follow_up_cadence", "daily")
+
+
+def test_set_setting_proactive_surfacing_bool_valid(tmp_db: object) -> None:
+    set_setting("proactive_surfacing", True)
+    assert get_setting("proactive_surfacing") is True
+
+
+def test_set_setting_proactive_surfacing_string_valid(tmp_db: object) -> None:
+    # existing code stores and reads proactive_surfacing as "true"/"false" strings
+    set_setting("proactive_surfacing", "false")
+    assert get_setting("proactive_surfacing") == "false"
+
+
+def test_set_setting_proactive_surfacing_invalid_raises(tmp_db: object) -> None:
+    with pytest.raises(ValueError, match="proactive_surfacing"):
+        set_setting("proactive_surfacing", "yes")
+
+
+def test_set_setting_unknown_key_passes_through(tmp_db: object) -> None:
+    # Internal cache entries (e.g. qc_cache_*) bypass validation
+    set_setting("qc_cache_abc123", {"timestamp": "2026-01-01", "found": False})
+    result = get_setting("qc_cache_abc123")
+    assert result == {"timestamp": "2026-01-01", "found": False}


### PR DESCRIPTION
## Issue

Closes #71

## What this PR does

Two hardening changes to `settings_repo.py`:

1. **Read safety**: `get_all_settings()` and `get_setting()` now wrap `json.loads` in `try/except json.JSONDecodeError`. Corrupt rows log a WARNING and are skipped rather than crashing the app.

2. **Write validation**: `set_setting()` validates value types for user-configurable keys before writing. `PATCH /settings` converts `ValueError` → HTTP 422.

Internal cache entries (`qc_cache_*`) bypass validation — they're not user-configurable and the proactive surfacing module writes them directly.

## Acceptance criteria

- [x] `get_all_settings()` skips corrupt JSON rows rather than crashing
- [x] `get_setting()` returns `None` for corrupt rows
- [x] `set_setting("max_tool_calls_per_turn", "abc")` raises `ValueError`
- [x] `set_setting("max_tool_calls_per_turn", 0)` raises `ValueError`
- [x] `set_setting("follow_up_cadence", "daily")` raises `ValueError`
- [x] `set_setting("max_tool_calls_per_turn", 6)` succeeds
- [x] Internal cache keys (`qc_cache_*`) pass through without validation
- [x] `PATCH /settings` returns 422 for invalid values

## Tests

- [x] 13 tests in `tests/unit/test_settings_repo.py`
- [x] `make lint` passes
- [x] `make test` passes (167 tests)
- [x] `make dev` starts cleanly after this change

## Docs

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/api.md` — N/A (422 already documented as possible response)
- [ ] `docs/architecture.md` — N/A

## Notes

`proactive_surfacing` is stored as the string `"true"`/`"false"` in existing code (not Python `bool`). The validator accepts both to preserve backward compatibility.