### PR TITLE
fix: #72 Session delete cascades messages and evicts memory cache

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tool call limit check now fires before the handler executes; counter checked with `>=` before increment so exactly `max_tool_calls_per_turn` calls are permitted (#70)
 - `get_all_settings()` and `get_setting()` no longer crash on corrupt JSON in the settings table — bad rows are skipped with a warning (#71)
 - `set_setting()` validates value types for user-configurable keys; raises `ValueError` on invalid input, which the settings router converts to HTTP 422 (#71)
+- Deleting a session now cascades to remove all its messages (FK constraint was already in schema; `PRAGMA foreign_keys = ON` was already in connection); in-memory session cache is also evicted on delete (#72)
 
 ### v1.0 — Distribution
 

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -81,6 +81,11 @@ def _get_or_create_session(session_id: str) -> Session:
     return _sessions[session_id]
 
 
+def evict_session(session_id: str) -> None:
+    """Remove a session from the in-memory cache. Called when a session is deleted."""
+    _sessions.pop(session_id, None)
+
+
 class MessageBody(BaseModel):
     content: str
 

--- a/src/weles/api/routers/sessions.py
+++ b/src/weles/api/routers/sessions.py
@@ -5,6 +5,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from weles.api.routers.messages import evict_session
 from weles.api.session_start import run_session_start_checks
 from weles.db.connection import get_db
 
@@ -94,3 +95,4 @@ async def delete_session(session_id: str) -> None:
     conn = get_db()
     conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
     conn.commit()
+    evict_session(session_id)

--- a/tests/integration/test_session_delete.py
+++ b/tests/integration/test_session_delete.py
@@ -1,0 +1,43 @@
+"""Integration tests: deleting a session cascades to messages and clears in-memory state."""
+from fastapi.testclient import TestClient
+
+
+def test_delete_session_removes_messages(client: TestClient, mock_claude: object) -> None:
+    # Create session
+    r = client.post("/sessions")
+    assert r.status_code == 201
+    session_id = r.json()["id"]
+
+    # Send a message so the messages table has rows
+    r = client.post(f"/sessions/{session_id}/messages", json={"content": "hello"})
+    assert r.status_code == 200
+
+    # Delete the session
+    r = client.delete(f"/sessions/{session_id}")
+    assert r.status_code == 204
+
+    # Verify messages are gone via DB query
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
+    ).fetchone()[0]
+    assert count == 0
+
+
+def test_delete_session_not_in_list(client: TestClient) -> None:
+    r = client.post("/sessions")
+    assert r.status_code == 201
+    session_id = r.json()["id"]
+
+    client.delete(f"/sessions/{session_id}")
+
+    sessions = client.get("/sessions").json()
+    ids = [s["id"] for s in sessions]
+    assert session_id not in ids
+
+
+def test_delete_nonexistent_session_returns_404(client: TestClient) -> None:
+    r = client.delete("/sessions/does-not-exist")
+    assert r.status_code == 404

--- a/tests/unit/test_session_memory.py
+++ b/tests/unit/test_session_memory.py
@@ -1,0 +1,38 @@
+"""Unit tests: in-memory session cache eviction on delete."""
+
+from weles.agent.session import Session
+from weles.api.routers.messages import _sessions, evict_session
+
+
+def test_evict_session_removes_from_cache() -> None:
+    session_id = "test-evict-123"
+    _sessions[session_id] = Session()
+    assert session_id in _sessions
+
+    evict_session(session_id)
+
+    assert session_id not in _sessions
+
+
+def test_evict_session_noop_for_unknown_id() -> None:
+    # Should not raise for a session that was never loaded
+    evict_session("nonexistent-id-xyz")
+
+
+def test_evict_session_called_on_delete(tmp_db: object) -> None:
+    """delete_session endpoint calls evict_session after DB delete."""
+    from fastapi.testclient import TestClient
+
+    from weles.api.main import app
+
+    with TestClient(app) as client:
+        r = client.post("/sessions")
+        session_id = r.json()["id"]
+
+        # Manually populate the in-memory cache to simulate a prior request
+        _sessions[session_id] = Session()
+        assert session_id in _sessions
+
+        client.delete(f"/sessions/{session_id}")
+
+        assert session_id not in _sessions


### PR DESCRIPTION
## Issue

Closes #72

## What this PR does

Two fixes for session deletion leaving stale state:

1. **DB cascade**: The `ON DELETE CASCADE` foreign key on `messages.session_id` was already present in the schema (migration 001). `PRAGMA foreign_keys = ON` was already set in `connection.py`. No migration needed — the cascade already works when the PRAGMA is active.

2. **Memory eviction**: Added `evict_session(session_id)` to `messages.py`. The delete endpoint in `sessions.py` calls it after a successful DB delete. Session objects no longer accumulate in `_sessions` indefinitely.

## Acceptance criteria

- [x] Deleting a session removes all its messages (cascade via FK)
- [x] `GET /sessions` does not include the deleted session after delete
- [x] In-memory `_sessions` dict no longer contains the session ID after delete

## Tests

- [x] `tests/integration/test_session_delete.py` — cascade, list visibility, 404 on nonexistent
- [x] `tests/unit/test_session_memory.py` — evict function, noop for unknown ID, called by delete endpoint
- [x] `make lint` passes
- [x] `make test` passes (173 tests)

## Docs

- [x] `CHANGELOG.md` updated
- [ ] `docs/api.md` — N/A
- [ ] `docs/architecture.md` — N/A

## Notes

Investigation showed both the FK constraint and the `PRAGMA foreign_keys = ON` were already in place. The only real bug was the missing `_sessions` eviction on delete.