### PR TITLE
fix: #73 Context compression overwrites wrong message when content is duplicated

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `get_all_settings()` and `get_setting()` no longer crash on corrupt JSON in the settings table — bad rows are skipped with a warning (#71)
 - `set_setting()` validates value types for user-configurable keys; raises `ValueError` on invalid input, which the settings router converts to HTTP 422 (#71)
 - Deleting a session now cascades to remove all its messages (FK constraint was already in schema; `PRAGMA foreign_keys = ON` was already in connection); in-memory session cache is also evicted on delete (#72)
+- Context compression now matches messages by ID instead of content; previously two messages with identical text could cause the wrong one to be overwritten (#73)
 
 ### v1.0 — Distribution
 

--- a/src/weles/agent/compression.py
+++ b/src/weles/agent/compression.py
@@ -80,14 +80,12 @@ async def maybe_compress_context(
             a["content"] = compressed
             a["is_compressed"] = True
             conn.execute(
-                "UPDATE messages SET content = ?, is_compressed = 1"
-                " WHERE session_id = ? AND role = 'user' AND content = ?",
-                (compressed, session_id, u_text),
+                "UPDATE messages SET content = ?, is_compressed = 1 WHERE id = ?",
+                (compressed, u["id"]),
             )
             conn.execute(
-                "UPDATE messages SET content = ?, is_compressed = 1"
-                " WHERE session_id = ? AND role = 'assistant' AND content = ?",
-                (compressed, session_id, a_text),
+                "UPDATE messages SET content = ?, is_compressed = 1 WHERE id = ?",
+                (compressed, a["id"]),
             )
             i += 2
         else:

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -101,12 +101,13 @@ def _get_session(session_id: str) -> dict[str, Any]:
 def _load_history(session_id: str) -> list[dict[str, Any]]:
     conn = get_db()
     rows = conn.execute(
-        "SELECT role, content, is_compressed FROM messages"
+        "SELECT id, role, content, is_compressed FROM messages"
         " WHERE session_id = ? ORDER BY created_at ASC",
         (session_id,),
     ).fetchall()
     return [
         {
+            "id": row["id"],
             "role": row["role"],
             "content": row["content"],
             "is_compressed": bool(row["is_compressed"]),

--- a/tests/unit/test_compression.py
+++ b/tests/unit/test_compression.py
@@ -1,0 +1,120 @@
+"""Tests for context compression — specifically that updates target rows by ID."""
+
+import uuid
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from weles.agent.compression import maybe_compress_context
+from weles.agent.session import Session
+
+
+def _insert_messages(conn: object, session_id: str, pairs: list[tuple[str, str]]) -> list[str]:
+    """Insert user+assistant message pairs, return list of inserted IDs (in order)."""
+    ids: list[str] = []
+    now = datetime.utcnow()
+    for i, (user_content, assistant_content) in enumerate(pairs):
+        uid = str(uuid.uuid4())
+        aid = str(uuid.uuid4())
+        offset = timedelta(seconds=i * 2)
+        conn.execute(  # type: ignore[union-attr]
+            "INSERT INTO messages"
+            " (id, session_id, role, content, tool_name, is_compressed, created_at)"
+            " VALUES (?, ?, 'user', ?, NULL, 0, ?)",
+            (uid, session_id, user_content, now + offset),
+        )
+        conn.execute(  # type: ignore[union-attr]
+            "INSERT INTO messages"
+            " (id, session_id, role, content, tool_name, is_compressed, created_at)"
+            " VALUES (?, ?, 'assistant', ?, NULL, 0, ?)",
+            (aid, session_id, assistant_content, now + offset + timedelta(seconds=1)),
+        )
+        ids.extend([uid, aid])
+    conn.commit()  # type: ignore[union-attr]
+    return ids
+
+
+def _make_session_from_db(session_id: str) -> Session:
+    """Load messages from DB into a Session (mirrors _load_history behaviour)."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT id, role, content, is_compressed FROM messages"
+        " WHERE session_id = ? ORDER BY created_at ASC",
+        (session_id,),
+    ).fetchall()
+    session = Session(session_id)
+    session.messages = [
+        {
+            "id": row["id"],
+            "role": row["role"],
+            "content": row["content"],
+            "is_compressed": bool(row["is_compressed"]),
+        }
+        for row in rows
+    ]
+    return session
+
+
+@pytest.mark.asyncio
+async def test_compression_uses_id_not_content(tmp_db: object) -> None:
+    """When two user messages have identical text, only the first is compressed."""
+    from weles.db.connection import get_db
+
+    conn = get_db()
+
+    # Create a session
+    session_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO sessions (id, title, mode, created_at) VALUES (?, NULL, 'general', ?)",
+        (session_id, datetime.utcnow()),
+    )
+    conn.commit()
+
+    # Insert 10 pairs so oldest pair is a compression candidate.
+    # Pairs 0 and 2 both have user content "ok" — this is the duplicate-content trap.
+    pairs = [
+        ("ok", "sure"),  # pair 0 — oldest, will be compressed
+        ("what about X?", "X is good"),  # pair 1
+        ("ok", "noted"),  # pair 2 — same user text, should NOT be compressed
+        ("another thing", "alright"),  # pair 3
+        ("more", "yes"),  # pair 4
+        ("test", "response"),  # pair 5
+        ("query", "answer"),  # pair 6
+        ("question", "answer2"),  # pair 7
+        ("ask", "reply"),  # pair 8
+        ("final", "done"),  # pair 9 — recent, protected tail
+    ]
+    ids = _insert_messages(conn, session_id, pairs)
+    # ids[0] = pair0 user "ok" (will be compressed)
+    # ids[1] = pair0 assistant "sure"
+    # ids[4] = pair2 user "ok" (must NOT be compressed)
+
+    session = _make_session_from_db(session_id)
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Summary of the exchange.")]
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+
+    # Force compression to fire regardless of token count
+    from unittest.mock import patch
+
+    with patch("weles.agent.compression.needs_compression", return_value=True):
+        await maybe_compress_context(session_id, mock_client, session)
+
+    # pair0 user "ok" should be compressed
+    pair0_user = conn.execute(
+        "SELECT content, is_compressed FROM messages WHERE id = ?", (ids[0],)
+    ).fetchone()
+    assert pair0_user["is_compressed"] == 1
+    assert pair0_user["content"].startswith("[Compressed]")
+
+    # pair2 user "ok" must remain unchanged — old bug would have overwritten this too
+    pair2_user = conn.execute(
+        "SELECT content, is_compressed FROM messages WHERE id = ?", (ids[4],)
+    ).fetchone()
+    assert pair2_user["is_compressed"] == 0
+    assert pair2_user["content"] == "ok"


### PR DESCRIPTION
## Summary
- Changed `_load_history()` to include `id` in the SELECT so message dicts carry their DB primary key
- Changed both UPDATE statements in `maybe_compress_context` from `WHERE content = ?` to `WHERE id = ?` — eliminates the content-collision bug
- Added `test_compression_uses_id_not_content`: inserts 10 pairs with two identical user messages "ok"; asserts only pair 0 (by ID) is compressed, pair 2 is untouched

## Acceptance criteria
- [x] UPDATE uses message ID, not content text
- [x] `_load_history` includes `id` field in returned dicts
- [x] Test verifies duplicate-content messages are disambiguated by ID

## Docs
- [x] CHANGELOG updated under v1.1 Fixed

## Notes
`needs_compression` is patched to `True` in the test — the short test strings don't reach 80% of the context window, so without the patch the compression path wouldn't execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)