### PR TITLE
fix: #74 Frontend error robustness

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `set_setting()` validates value types for user-configurable keys; raises `ValueError` on invalid input, which the settings router converts to HTTP 422 (#71)
 - Deleting a session now cascades to remove all its messages (FK constraint was already in schema; `PRAGMA foreign_keys = ON` was already in connection); in-memory session cache is also evicted on delete (#72)
 - Context compression now matches messages by ID instead of content; previously two messages with identical text could cause the wrong one to be overwritten (#73)
+- SSE data-line parsing now wraps `JSON.parse` in try-catch; a malformed event no longer terminates the stream handler (#74)
+- All `api.ts` fetch calls now check `r.ok` before calling `.json()`; HTTP errors throw instead of crashing silently as parse errors (#74)
+- Settings, Information, and History pages show "Failed to load — try refreshing" instead of spinning "Loading…" indefinitely when the backend is unreachable (#74)
+- Null response body (network failure before headers complete) now removes the frozen assistant placeholder and shows "Connection failed — try again" (#74)
+- `newChat()` preserves the currently selected mode instead of always resetting to `general` (#74)
 
 ### v1.0 — Distribution
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -296,3 +296,5 @@ body {
 .history-table td { padding: 8px 10px; border-bottom: 1px solid #1e1e1e; color: #ccc; }
 .history-table tr:hover td { background: #161616; }
 .history-notes { color: #666; cursor: default; }
+
+.page-error { color: #e07070; font-size: 14px; margin-top: 16px; }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
   const [confirmClear, setConfirmClear] = useState(false)
   const [decayDraft, setDecayDraft] = useState<Record<string, number>>(DECAY_DEFAULTS)
   const [settingsLoaded, setSettingsLoaded] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     getSettings().then(s => {
@@ -44,7 +45,7 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
       const fromServer = (s.decay_thresholds as Record<string, number>) ?? {}
       setDecayDraft({ ...DECAY_DEFAULTS, ...fromServer })
       setSettingsLoaded(true)
-    })
+    }).catch(() => setError('Failed to load settings — try refreshing'))
   }, [])
 
   async function save(patch: Record<string, unknown>) {
@@ -63,6 +64,8 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
     await clearData()
     onBack()
   }
+
+  if (error) return <div className="settings-page"><button className="back-btn" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
 
   return (
     <div className="settings-page">
@@ -251,6 +254,7 @@ function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHist
   const [prefs, setPrefs] = useState<Preference[]>([])
   const [history, setHistory] = useState<HistoryItem[]>([])
   const [thresholds, setThresholds] = useState<DecayThresholds>({})
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     Promise.all([getProfile(), listPreferences(), listHistory(), getSettings()]).then(
@@ -260,7 +264,7 @@ function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHist
         setHistory(h)
         setThresholds((s.decay_thresholds as DecayThresholds) ?? {})
       }
-    )
+    ).catch(() => setError('Failed to load — try refreshing'))
   }, [])
 
   async function saveField(field: string, value: string) {
@@ -284,6 +288,7 @@ function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHist
     historySummary[item.domain][item.status] = (historySummary[item.domain][item.status] ?? 0) + 1
   }
 
+  if (error) return <div className="info-page"><button className="back-btn" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
   if (!profile) return <div className="info-page"><button className="back-btn" onClick={onBack}>← Back</button><p>Loading…</p></div>
 
   return (
@@ -353,15 +358,20 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
   const [items, setItems] = useState<HistoryItem[]>([])
   const [domain, setDomain] = useState('')
   const [status, setStatus] = useState('')
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    listHistory(domain || undefined, status || undefined).then(setItems)
+    listHistory(domain || undefined, status || undefined).then(setItems).catch(() =>
+      setError('Failed to load — try refreshing')
+    )
   }, [domain, status])
 
   async function handleDelete(id: string) {
     await deleteHistoryItem(id)
     setItems(prev => prev.filter(i => i.id !== id))
   }
+
+  if (error) return <div className="history-page"><button className="back-btn" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
 
   return (
     <div className="history-page">
@@ -449,7 +459,10 @@ export default function App() {
         : []
     )
     setToolProgress([])
-    setMode('general')
+    // Preserve current mode; patch the session if it differs from the default 'general'
+    if (mode !== 'general') {
+      await patchSession(session.id, { mode })
+    }
     setPage('chat')
     return session.id
   }
@@ -458,6 +471,7 @@ export default function App() {
     setActiveId(id)
     setPage('chat')
     const r = await fetch(`/sessions/${id}/messages`)
+    if (!r.ok) throw new Error(`HTTP ${r.status}`)
     const msgs = await r.json()
     setMessages(
       msgs
@@ -511,6 +525,11 @@ export default function App() {
     })
 
     if (!resp.body) {
+      setMessages(prev => prev.filter(m => m.id !== assistantId))
+      setMessages(prev => [
+        ...prev,
+        { id: assistantId, role: 'assistant', content: 'Connection failed — try again.' },
+      ])
       setStreaming(false)
       return
     }
@@ -531,7 +550,13 @@ export default function App() {
         if (line.startsWith('event:')) {
           currentEvent = line.slice(6).trim()
         } else if (line.startsWith('data:')) {
-          const payload = JSON.parse(line.slice(5).trim())
+          let payload: Record<string, unknown>
+          try {
+            payload = JSON.parse(line.slice(5).trim()) as Record<string, unknown>
+          } catch (e) {
+            if (e instanceof SyntaxError) { console.warn('SSE parse error', line); continue }
+            throw e
+          }
           if (currentEvent === 'text_delta') {
             setMessages(prev =>
               prev.map(m =>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,13 +1,18 @@
 import type { HistoryItem, Mode, Preference, Session, UserProfile } from './types'
 
+function checkOk(r: Response): Response {
+  if (!r.ok) throw new Error(`HTTP ${r.status}`)
+  return r
+}
+
 export async function createSession(): Promise<Session> {
   const r = await fetch('/sessions', { method: 'POST' })
-  return r.json()
+  return checkOk(r).json()
 }
 
 export async function listSessions(): Promise<Session[]> {
   const r = await fetch('/sessions')
-  return r.json()
+  return checkOk(r).json()
 }
 
 export async function deleteSession(id: string): Promise<void> {
@@ -20,12 +25,12 @@ export async function patchSession(id: string, patch: { title?: string; mode?: M
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(patch),
   })
-  return r.json()
+  return checkOk(r).json()
 }
 
 export async function getSettings(): Promise<Record<string, unknown>> {
   const r = await fetch('/settings')
-  return r.json()
+  return checkOk(r).json()
 }
 
 export async function patchSettings(patch: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -34,12 +39,12 @@ export async function patchSettings(patch: Record<string, unknown>): Promise<Rec
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(patch),
   })
-  return r.json()
+  return checkOk(r).json()
 }
 
 export async function getProfile(): Promise<UserProfile> {
   const r = await fetch('/profile')
-  return r.json()
+  return checkOk(r).json()
 }
 
 export async function patchProfile(patch: Record<string, unknown>): Promise<UserProfile> {
@@ -48,12 +53,12 @@ export async function patchProfile(patch: Record<string, unknown>): Promise<User
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(patch),
   })
-  return r.json()
+  return checkOk(r).json()
 }
 
 export async function listPreferences(): Promise<Preference[]> {
   const r = await fetch('/preferences')
-  return r.json()
+  return checkOk(r).json()
 }
 
 export async function deletePreference(id: string): Promise<void> {
@@ -71,7 +76,7 @@ export async function listHistory(domain?: string, status?: string): Promise<His
   if (status) params.set('status', status)
   const query = params.toString()
   const r = await fetch(`/history${query ? `?${query}` : ''}`)
-  return r.json()
+  return checkOk(r).json()
 }
 
 export async function deleteHistoryItem(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- **SSE JSON.parse**: wrapped in try-catch for `SyntaxError`; malformed event logs to console and continues, stream is not terminated
- **`api.ts` `r.ok` checks**: all GET/POST/PATCH calls now throw `Error("HTTP N")` on non-2xx; `checkOk()` helper added
- **Page error states**: Settings, Information, History pages set `error` state on fetch failure and render "Failed to load — try refreshing" instead of infinite "Loading…"
- **Null body**: removes the frozen assistant placeholder, inserts "Connection failed — try again" in its place
- **Mode preservation**: `newChat()` no longer resets mode to `general`; patches the session if the current mode differs

## Acceptance criteria
- [x] SSE parse error is caught by `SyntaxError`-specific try-catch; stream continues
- [x] All `api.ts` fetch calls check `r.ok` before `.json()`
- [x] Settings/Information/History show error text (not perpetual spinner) when backend is down
- [x] Null body case: placeholder removed, error message shown in chat
- [x] Mode preserved across `newChat()` call

## Docs
- [x] CHANGELOG updated under v1.1 Fixed

## Notes
No automated tests (issue spec: manual verification only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)