### PR TITLE
feat: #75 Add database indices for frequently queried columns

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ dist/
 alembic/versions/*.py
 !alembic/versions/.gitkeep
 !alembic/versions/001_initial.py
+!alembic/versions/002_add_indices.py
 
 # Node
 frontend/node_modules/
@@ -51,3 +52,7 @@ Thumbs.db
 .ruff_cache/
 htmlcov/
 .coverage
+
+# Claude Code local settings
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Bug fixes
 
+#### Added
+- DB indices for `messages.session_id`, `history.domain`, `history.status`, `history.follow_up_due_at`, `history.check_in_due_at`, and `preferences.dimension` via Alembic migration `002_add_indices` (#75)
+
 #### Fixed
 - Information tab content is now scrollable when it exceeds the viewport height; settings page receives the same fix (#68)
 - Tool call limit check now fires before the handler executes; counter checked with `>=` before increment so exactly `max_tool_calls_per_turn` calls are permitted (#70)

--- a/alembic/versions/002_add_indices.py
+++ b/alembic/versions/002_add_indices.py
@@ -1,0 +1,31 @@
+"""Add indices for frequently queried columns
+
+Revision ID: 002_add_indices
+Revises: 001_initial
+Create Date: 2026-04-18
+"""
+
+from alembic import op
+
+revision = "002_add_indices"
+down_revision = "001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("idx_messages_session_id", "messages", ["session_id"])
+    op.create_index("idx_history_domain", "history", ["domain"])
+    op.create_index("idx_history_status", "history", ["status"])
+    op.create_index("idx_history_follow_up_due", "history", ["follow_up_due_at"])
+    op.create_index("idx_history_check_in_due", "history", ["check_in_due_at"])
+    op.create_index("idx_preferences_dimension", "preferences", ["dimension"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_messages_session_id", "messages")
+    op.drop_index("idx_history_domain", "history")
+    op.drop_index("idx_history_status", "history")
+    op.drop_index("idx_history_follow_up_due", "history")
+    op.drop_index("idx_history_check_in_due", "history")
+    op.drop_index("idx_preferences_dimension", "preferences")

--- a/tests/integration/test_indices.py
+++ b/tests/integration/test_indices.py
@@ -1,0 +1,20 @@
+"""Integration test: all expected indices exist after alembic upgrade head."""
+from weles.db.connection import get_db
+
+EXPECTED_INDICES = {
+    "idx_messages_session_id",
+    "idx_history_domain",
+    "idx_history_status",
+    "idx_history_follow_up_due",
+    "idx_history_check_in_due",
+    "idx_preferences_dimension",
+}
+
+
+def test_all_indices_exist(tmp_db: object) -> None:
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    existing = {row["name"] for row in rows}
+    assert existing >= EXPECTED_INDICES, f"Missing indices: {EXPECTED_INDICES - existing}"

--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -40,4 +40,4 @@ def test_alembic_revision(tmp_db: Path) -> None:
     conn = sqlite3.connect(tmp_db)
     revision = conn.execute("SELECT version_num FROM alembic_version").fetchone()[0]
     conn.close()
-    assert revision == "001_initial"
+    assert revision == "002_add_indices"


### PR DESCRIPTION
## Summary
- New Alembic migration `002_add_indices` adds six indices covering the highest-frequency query patterns
- Downgrade path drops all six indices
- Updated `test_alembic_revision` to expect `002_add_indices`

## Indices added
- `idx_messages_session_id` — queried on every page load and SSE turn
- `idx_history_domain` — queried by `get_history_context()` on every non-general message
- `idx_history_status` — queried by history list and session-start checks
- `idx_history_follow_up_due` — scanned by `check_follow_up()` on every session start
- `idx_history_check_in_due` — scanned by `check_check_in()` on every session start
- `idx_preferences_dimension` — used in upsert conflict detection

## Acceptance criteria
- [x] `002_add_indices` migration creates all six indices
- [x] Downgrade drops them
- [x] `tests/integration/test_indices.py` queries `sqlite_master` and asserts all six names exist
- [x] `make test` passes (175 tests)

## Docs
- [x] CHANGELOG updated under v1.1 Added

🤖 Generated with [Claude Code](https://claude.com/claude-code)