### PR TITLE
feat: #76 LRU session cache capped at 50 entries

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Added
 - DB indices for `messages.session_id`, `history.domain`, `history.status`, `history.follow_up_due_at`, `history.check_in_due_at`, and `preferences.dimension` via Alembic migration `002_add_indices` (#75)
+- In-memory session cache replaced with an LRU cache capped at 50 sessions (configurable via `WELES_SESSION_CACHE_SIZE`); oldest session is evicted when the limit is exceeded (#76)
 
 #### Fixed
 - Information tab content is now scrollable when it exceeds the viewport height; settings page receives the same fix (#68)

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
+import os
 import uuid
+from collections import OrderedDict
 from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import datetime
 from typing import Any
@@ -71,14 +73,21 @@ _MODE_TO_DOMAIN = {
 
 router = APIRouter(tags=["messages"])
 
-# In-memory per-session state (survives requests, reset on server restart)
-_sessions: dict[str, Session] = {}
+_SESSION_CACHE_SIZE = int(os.environ.get("WELES_SESSION_CACHE_SIZE", "50"))
+
+# LRU cache capped at _SESSION_CACHE_SIZE entries (OrderedDict move_to_end pattern)
+_sessions: OrderedDict[str, Session] = OrderedDict()
 
 
 def _get_or_create_session(session_id: str) -> Session:
-    if session_id not in _sessions:
-        _sessions[session_id] = Session()
-    return _sessions[session_id]
+    if session_id in _sessions:
+        _sessions.move_to_end(session_id)
+        return _sessions[session_id]
+    session = Session()
+    _sessions[session_id] = session
+    if len(_sessions) > _SESSION_CACHE_SIZE:
+        _sessions.popitem(last=False)
+    return session
 
 
 def evict_session(session_id: str) -> None:

--- a/tests/unit/test_session_cache.py
+++ b/tests/unit/test_session_cache.py
@@ -1,0 +1,62 @@
+"""Tests for LRU session cache in messages router."""
+import pytest
+
+import weles.api.routers.messages as messages_mod
+
+
+@pytest.fixture(autouse=True)
+def _clear_sessions():
+    """Reset the LRU cache before each test."""
+    messages_mod._sessions.clear()
+    yield
+    messages_mod._sessions.clear()
+
+
+def test_oldest_evicted_when_cache_full():
+    original_size = messages_mod._SESSION_CACHE_SIZE
+    messages_mod._SESSION_CACHE_SIZE = 3
+    try:
+        for i in range(4):
+            messages_mod._get_or_create_session(f"session-{i}")
+        # session-0 should have been evicted
+        assert "session-0" not in messages_mod._sessions
+        assert "session-1" in messages_mod._sessions
+        assert "session-2" in messages_mod._sessions
+        assert "session-3" in messages_mod._sessions
+    finally:
+        messages_mod._SESSION_CACHE_SIZE = original_size
+
+
+def test_evict_session_removes_from_cache():
+    messages_mod._get_or_create_session("abc")
+    assert "abc" in messages_mod._sessions
+    messages_mod.evict_session("abc")
+    assert "abc" not in messages_mod._sessions
+
+
+def test_evict_session_unknown_id_is_noop():
+    messages_mod.evict_session("does-not-exist")  # must not raise
+
+
+def test_get_or_create_returns_same_object():
+    s1 = messages_mod._get_or_create_session("xyz")
+    s2 = messages_mod._get_or_create_session("xyz")
+    assert s1 is s2
+
+
+def test_access_promotes_to_most_recent():
+    """Accessing an existing entry promotes it so it is not evicted next."""
+    original_size = messages_mod._SESSION_CACHE_SIZE
+    messages_mod._SESSION_CACHE_SIZE = 3
+    try:
+        messages_mod._get_or_create_session("old")
+        messages_mod._get_or_create_session("middle")
+        messages_mod._get_or_create_session("new")
+        # Re-access "old" to promote it
+        messages_mod._get_or_create_session("old")
+        # Adding another entry should evict "middle" (now the LRU)
+        messages_mod._get_or_create_session("newest")
+        assert "old" in messages_mod._sessions
+        assert "middle" not in messages_mod._sessions
+    finally:
+        messages_mod._SESSION_CACHE_SIZE = original_size


### PR DESCRIPTION
## Summary
- Replaced `dict[str, Session]` with `OrderedDict[str, Session]` using the standard `move_to_end` / `popitem(last=False)` LRU pattern
- Cache limit defaults to 50, overridable via `WELES_SESSION_CACHE_SIZE` env var
- `evict_session()` unchanged — still used by DELETE endpoint

## Acceptance criteria
- [x] Adding 51 sessions with cache size 3 evicts the oldest (test: `test_oldest_evicted_when_cache_full`)
- [x] Accessing an existing entry promotes it so it survives the next eviction (test: `test_access_promotes_to_most_recent`)
- [x] `evict_session()` removes the entry (test: `test_evict_session_removes_from_cache`)
- [x] Unknown-ID eviction is a no-op (test: `test_evict_session_unknown_id_is_noop`)
- [x] Same object returned for repeated `_get_or_create_session()` calls (test: `test_get_or_create_returns_same_object`)

## Docs
- [x] CHANGELOG updated under v1.1 Added

## Notes
No new dependency added — used `collections.OrderedDict` from stdlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)