### PR TITLE
feat: #77 Server-side pagination for history and message endpoints

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### Added
 - DB indices for `messages.session_id`, `history.domain`, `history.status`, `history.follow_up_due_at`, `history.check_in_due_at`, and `preferences.dimension` via Alembic migration `002_add_indices` (#75)
 - In-memory session cache replaced with an LRU cache capped at 50 sessions (configurable via `WELES_SESSION_CACHE_SIZE`); oldest session is evicted when the limit is exceeded (#76)
+- `GET /history` now returns a paginated envelope `{items, total, limit, offset}`; supports `limit` and `offset` query params (default 50/0) (#77)
+- `GET /sessions/{id}/messages` supports `limit` (default 100) and `before_id` cursor for loading older messages (#77)
+- History page shows "Load more" button when more items exist beyond the first page (#77)
+- Chat loads last 100 messages on session select; "Load older messages" button prepends the preceding 100 (#77)
 
 #### Fixed
 - Information tab content is now scrollable when it exceeds the viewport height; settings page receives the same fix (#68)

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,7 +102,11 @@ event: error          data: {"message": "Claude API unavailable"}
 `tool_error` is non-fatal — stream continues. `error` terminates the stream.
 
 ### `GET /sessions/{id}/messages`
-Retrieve full message history for a session.
+Retrieve paginated message history for a session.
+
+**Query params** (all optional):
+- `limit`: max messages to return (default `100`)
+- `before_id`: cursor — return up to `limit` messages with `created_at` before this message ID, in chronological order
 
 **Response `200`** — array of:
 ```json
@@ -116,6 +120,9 @@ Retrieve full message history for a session.
   "created_at": "ISO datetime"
 }
 ```
+
+When `before_id` is not provided: returns the last `limit` messages chronologically.
+When `before_id` is provided: returns up to `limit` messages preceding that message ID.
 
 ---
 
@@ -147,13 +154,23 @@ Partial update. Updates `field_timestamps` atomically with each changed field.
 ## History
 
 ### `GET /history`
-List history items, most recent first.
+List history items, most recent first, with pagination.
 
 **Query params** (all optional):
 - `domain`: `shopping|diet|fitness|lifestyle`
 - `status`: `recommended|bought|tried|rated|skipped`
+- `limit`: items per page (default `50`)
+- `offset`: number of items to skip (default `0`)
 
-**Response `200`** — array of history items
+**Response `200`**:
+```json
+{
+  "items": [...],
+  "total": 75,
+  "limit": 50,
+  "offset": 0
+}
+```
 
 ### `DELETE /history/{id}`
 Delete a history item.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -298,3 +298,8 @@ body {
 .history-notes { color: #666; cursor: default; }
 
 .page-error { color: #e07070; font-size: 14px; margin-top: 16px; }
+
+.load-more-btn { margin-top: 12px; background: #1e1e1e; border: 1px solid #333; color: #ccc; padding: 8px 20px; border-radius: 6px; cursor: pointer; font-size: 13px; }
+.load-more-btn:hover { background: #2a2a2a; }
+.load-older-btn { display: block; margin: 0 auto 12px; background: transparent; border: 1px solid #333; color: #888; padding: 6px 16px; border-radius: 6px; cursor: pointer; font-size: 12px; }
+.load-older-btn:hover { color: #ccc; border-color: #555; }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { clearData, createSession, deleteHistoryItem, deletePreference, deleteSession, getProfile, getSettings, listHistory, listPreferences, listSessions, patchProfile, patchSession, patchSettings } from './api'
+import { clearData, createSession, deleteHistoryItem, deletePreference, deleteSession, getProfile, getSessionMessages, getSettings, listHistory, listPreferences, listSessions, patchProfile, patchSession, patchSettings } from './api'
 import type { ChatMessage, HistoryItem, Mode, Preference, Session, ToolProgress, UserProfile } from './types'
 import './App.css'
 
@@ -258,10 +258,10 @@ function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHist
 
   useEffect(() => {
     Promise.all([getProfile(), listPreferences(), listHistory(), getSettings()]).then(
-      ([p, pr, h, s]) => {
+      ([p, pr, hPage, s]) => {
         setProfile(p)
         setPrefs(pr)
-        setHistory(h)
+        setHistory(hPage.items)
         setThresholds((s.decay_thresholds as DecayThresholds) ?? {})
       }
     ).catch(() => setError('Failed to load — try refreshing'))
@@ -356,19 +356,34 @@ const STATUSES = ['', 'recommended', 'bought', 'tried', 'rated', 'skipped']
 
 function HistoryPage({ onBack }: { onBack: () => void }) {
   const [items, setItems] = useState<HistoryItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [offset, setOffset] = useState(0)
   const [domain, setDomain] = useState('')
   const [status, setStatus] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const LIMIT = 50
 
   useEffect(() => {
-    listHistory(domain || undefined, status || undefined).then(setItems).catch(() =>
-      setError('Failed to load — try refreshing')
-    )
+    setItems([])
+    setOffset(0)
+    setTotal(0)
+    listHistory(domain || undefined, status || undefined, LIMIT, 0)
+      .then(page => { setItems(page.items); setTotal(page.total) })
+      .catch(() => setError('Failed to load — try refreshing'))
   }, [domain, status])
+
+  async function loadMore() {
+    const nextOffset = offset + LIMIT
+    const page = await listHistory(domain || undefined, status || undefined, LIMIT, nextOffset)
+    setItems(prev => [...prev, ...page.items])
+    setOffset(nextOffset)
+    setTotal(page.total)
+  }
 
   async function handleDelete(id: string) {
     await deleteHistoryItem(id)
     setItems(prev => prev.filter(i => i.id !== id))
+    setTotal(prev => prev - 1)
   }
 
   if (error) return <div className="history-page"><button className="back-btn" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
@@ -422,6 +437,9 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
           </table>
         )
       }
+      {total > offset + LIMIT && (
+        <button className="load-more-btn" onClick={loadMore}>Load more</button>
+      )}
     </div>
   )
 }
@@ -470,9 +488,7 @@ export default function App() {
   async function selectSession(id: string) {
     setActiveId(id)
     setPage('chat')
-    const r = await fetch(`/sessions/${id}/messages`)
-    if (!r.ok) throw new Error(`HTTP ${r.status}`)
-    const msgs = await r.json()
+    const msgs = await getSessionMessages(id)
     setMessages(
       msgs
         .filter((m: { role: string }) => m.role === 'user' || m.role === 'assistant')
@@ -485,6 +501,20 @@ export default function App() {
     const sess = sessions.find(s => s.id === id)
     if (sess) setMode(sess.mode as Mode)
     setToolProgress([])
+  }
+
+  async function loadOlderMessages(sessionId: string) {
+    if (messages.length === 0) return
+    const oldest = messages[0]
+    const older = await getSessionMessages(sessionId, 100, oldest.id)
+    const mapped = older
+      .filter((m: { role: string }) => m.role === 'user' || m.role === 'assistant')
+      .map((m: { id: string; role: string; content: string }) => ({
+        id: m.id,
+        role: m.role as 'user' | 'assistant',
+        content: m.content,
+      }))
+    setMessages(prev => [...mapped, ...prev])
   }
 
   async function removeSession(id: string, e: React.MouseEvent) {
@@ -654,6 +684,11 @@ export default function App() {
 
         {/* Messages */}
         <div className="messages">
+          {activeId && messages.length > 0 && (
+            <button className="load-older-btn" onClick={() => loadOlderMessages(activeId)}>
+              Load older messages
+            </button>
+          )}
           {messages.map(msg => (
             <div key={msg.id} className={`message ${msg.role}`}>
               <div className="bubble">

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -70,12 +70,32 @@ export async function clearData(): Promise<void> {
   if (!r.ok) throw new Error(`DELETE /data failed: ${r.status}`)
 }
 
-export async function listHistory(domain?: string, status?: string): Promise<HistoryItem[]> {
+export interface HistoryPage {
+  items: HistoryItem[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export async function listHistory(
+  domain?: string,
+  status?: string,
+  limit = 50,
+  offset = 0,
+): Promise<HistoryPage> {
   const params = new URLSearchParams()
   if (domain) params.set('domain', domain)
   if (status) params.set('status', status)
-  const query = params.toString()
-  const r = await fetch(`/history${query ? `?${query}` : ''}`)
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  const r = await fetch(`/history?${params.toString()}`)
+  return checkOk(r).json()
+}
+
+export async function getSessionMessages(sessionId: string, limit = 100, beforeId?: string): Promise<HistoryItem[]> {
+  const params = new URLSearchParams({ limit: String(limit) })
+  if (beforeId) params.set('before_id', beforeId)
+  const r = await fetch(`/sessions/${sessionId}/messages?${params.toString()}`)
   return checkOk(r).json()
 }
 

--- a/src/weles/api/routers/history.py
+++ b/src/weles/api/routers/history.py
@@ -9,9 +9,12 @@ router = APIRouter(tags=["history"])
 
 @router.get("/history")
 async def list_history(
-    domain: str | None = None, status: str | None = None
-) -> list[dict[str, Any]]:
-    return get_history(domain=domain, status=status)
+    domain: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    return get_history(domain=domain, status=status, limit=limit, offset=offset)
 
 
 @router.delete("/history/{item_id}", status_code=204)

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -308,11 +308,27 @@ def _agent_event_to_sse(event: AgentEvent, title: str, session_id: str) -> dict[
 
 
 @router.get("/sessions/{session_id}/messages")
-async def get_messages(session_id: str) -> list[dict[str, Any]]:
+async def get_messages(
+    session_id: str,
+    limit: int = 100,
+    before_id: str | None = None,
+) -> list[dict[str, Any]]:
     _get_session(session_id)
     conn = get_db()
+    if before_id is not None:
+        cursor_row = conn.execute(
+            "SELECT created_at FROM messages WHERE id = ?", (before_id,)
+        ).fetchone()
+        if cursor_row is None:
+            return []
+        rows = conn.execute(
+            "SELECT * FROM messages WHERE session_id = ? AND created_at < ?"
+            " ORDER BY created_at DESC LIMIT ?",
+            (session_id, cursor_row["created_at"], limit),
+        ).fetchall()
+        return list(reversed([dict(r) for r in rows]))
     rows = conn.execute(
-        "SELECT * FROM messages WHERE session_id = ? ORDER BY created_at ASC",
-        (session_id,),
+        "SELECT * FROM messages WHERE session_id = ? ORDER BY created_at DESC LIMIT ?",
+        (session_id, limit),
     ).fetchall()
-    return [dict(row) for row in rows]
+    return list(reversed([dict(r) for r in rows]))

--- a/src/weles/db/history_repo.py
+++ b/src/weles/db/history_repo.py
@@ -13,9 +13,14 @@ _STATUS_PREFIX: dict[str, str] = {
 }
 
 
-def get_history(domain: str | None = None, status: str | None = None) -> list[dict[str, Any]]:
+def get_history(
+    domain: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
     conn = get_db()
-    query = "SELECT * FROM history"
+    base = "FROM history"
     params: list[Any] = []
     filters = []
     if domain:
@@ -24,11 +29,18 @@ def get_history(domain: str | None = None, status: str | None = None) -> list[di
     if status:
         filters.append("status = ?")
         params.append(status)
-    if filters:
-        query += " WHERE " + " AND ".join(filters)
-    query += " ORDER BY created_at DESC"
-    rows = conn.execute(query, params).fetchall()
-    return [dict(row) for row in rows]
+    where = (" WHERE " + " AND ".join(filters)) if filters else ""
+    total: int = conn.execute(f"SELECT COUNT(*) {base}{where}", params).fetchone()[0]
+    rows = conn.execute(
+        f"SELECT * {base}{where} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+        params + [limit, offset],
+    ).fetchall()
+    return {
+        "items": [dict(row) for row in rows],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 def delete_history_item(item_id: str) -> bool:

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -59,7 +59,7 @@ def test_get_history_domain_filter(client: TestClient) -> None:
     _add(client, domain="fitness", status="bought")
     resp = client.get("/history?domain=shopping")
     assert resp.status_code == 200
-    items = resp.json()
+    items = resp.json()["items"]
     assert all(i["domain"] == "shopping" for i in items)
     assert any(i["domain"] == "shopping" for i in items)
 
@@ -69,7 +69,7 @@ def test_get_history_status_filter(client: TestClient) -> None:
     _add(client, status="bought")
     resp = client.get("/history?status=recommended")
     assert resp.status_code == 200
-    items = resp.json()
+    items = resp.json()["items"]
     assert all(i["status"] == "recommended" for i in items)
 
 

--- a/tests/integration/test_history_pagination.py
+++ b/tests/integration/test_history_pagination.py
@@ -1,0 +1,41 @@
+"""Integration tests: GET /history pagination."""
+import uuid
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from weles.db.connection import get_db
+
+
+def _seed_history(n: int) -> None:
+    conn = get_db()
+    for i in range(n):
+        conn.execute(
+            "INSERT INTO history"
+            " (id, item_name, category, domain, status, rating, notes,"
+            "  follow_up_due_at, check_in_due_at, created_at)"
+            " VALUES (?, ?, 'gear', 'fitness', 'bought', NULL, NULL, NULL, NULL, ?)",
+            (str(uuid.uuid4()), f"item-{i}", datetime.utcnow()),
+        )
+    conn.commit()
+
+
+def test_history_first_page(client: TestClient, tmp_db: object) -> None:
+    _seed_history(75)
+    r = client.get("/history?limit=50")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 75
+    assert body["limit"] == 50
+    assert body["offset"] == 0
+    assert len(body["items"]) == 50
+
+
+def test_history_second_page(client: TestClient, tmp_db: object) -> None:
+    _seed_history(75)
+    r = client.get("/history?limit=50&offset=50")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 75
+    assert len(body["items"]) == 25
+    assert body["offset"] == 50

--- a/tests/integration/test_messages_pagination.py
+++ b/tests/integration/test_messages_pagination.py
@@ -1,0 +1,54 @@
+"""Integration tests: GET /sessions/{id}/messages pagination."""
+import uuid
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from weles.db.connection import get_db
+
+
+def _seed_messages(session_id: str, n: int) -> list[str]:
+    """Insert n user messages; return their IDs in chronological order."""
+    conn = get_db()
+    ids: list[str] = []
+    base = datetime.utcnow()
+    for i in range(n):
+        mid = str(uuid.uuid4())
+        ids.append(mid)
+        conn.execute(
+            "INSERT INTO messages"
+            " (id, session_id, role, content, tool_name, is_compressed, created_at)"
+            " VALUES (?, ?, 'user', ?, NULL, 0, ?)",
+            (mid, session_id, f"msg-{i}", base + timedelta(seconds=i)),
+        )
+    conn.commit()
+    return ids
+
+
+def test_messages_last_page(client: TestClient, tmp_db: object, mock_claude: object) -> None:
+    r = client.post("/sessions")
+    session_id = r.json()["id"]
+    all_ids = _seed_messages(session_id, 150)
+
+    r = client.get(f"/sessions/{session_id}/messages?limit=100")
+    assert r.status_code == 200
+    msgs = r.json()
+    assert len(msgs) == 100
+    # Should be the LAST 100 messages (chronologically)
+    returned_ids = [m["id"] for m in msgs]
+    assert returned_ids == all_ids[50:]
+
+
+def test_messages_before_id(client: TestClient, tmp_db: object, mock_claude: object) -> None:
+    r = client.post("/sessions")
+    session_id = r.json()["id"]
+    all_ids = _seed_messages(session_id, 150)
+
+    # before_id is the 51st message (index 50); expect first 50 messages
+    before_id = all_ids[50]
+    r = client.get(f"/sessions/{session_id}/messages?limit=100&before_id={before_id}")
+    assert r.status_code == 200
+    msgs = r.json()
+    assert len(msgs) == 50
+    returned_ids = [m["id"] for m in msgs]
+    assert returned_ids == all_ids[:50]

--- a/tests/integration/test_shopping_mode.py
+++ b/tests/integration/test_shopping_mode.py
@@ -138,7 +138,7 @@ def test_add_to_history_dispatched_and_persisted(client: TestClient, mocker) -> 
 
     _stream_events(client, session_id, "what boots should I get")
 
-    history = client.get("/history?domain=shopping").json()
+    history = client.get("/history?domain=shopping").json()["items"]
     assert any(item["item_name"] == "Red Wing 875" for item in history)
 
 


### PR DESCRIPTION
## Summary
- `GET /history` now returns `{items, total, limit, offset}` envelope; defaults to 50/page
- `GET /sessions/{id}/messages` supports `limit` (default 100) and `before_id` cursor
- History page: "Load more" button appends next page
- Chat: session select fetches last 100 messages; "Load older messages" button prepends preceding 100
- Updated two existing tests that iterated `/history` response as a list

## Acceptance criteria
- [x] `GET /history?limit=50` returns 50 items and `total=75` when 75 exist
- [x] `GET /history?limit=50&offset=50` returns 25 items
- [x] `GET /sessions/{id}/messages?limit=100` returns last 100
- [x] `GET /sessions/{id}/messages?limit=100&before_id={id}` returns the 50 preceding messages
- [x] Frontend HistoryPage shows "Load more" when `total > offset + limit`
- [x] Frontend chat loads last 100 on select; "Load older messages" prepends older

## Docs
- [x] `docs/api.md` updated for both endpoints (breaking change documented)
- [x] CHANGELOG updated under v1.1 Added

## Notes
Breaking change: `GET /history` now returns an envelope instead of a plain array.
Updated `test_get_history_domain_filter`, `test_get_history_status_filter`, and `test_add_to_history_dispatched_and_persisted` to use `.json()["items"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)