### PR TITLE
feat: #78 Input length validation on message and tool endpoints

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### v1.1 — Hardening
+
+#### Fixed
+- `POST /sessions/{id}/messages` now rejects payloads with `content` exceeding 32,000 chars with HTTP 422 (#78)
+- Tool string inputs (item_name, category, notes, value, reason, query) are bounded by `maxLength` in JSON Schema and silently truncated in `dispatch.py` as a safety net (#78)
+
 ### v0.1 — Skeleton
 
 #### Added

--- a/src/weles/agent/dispatch.py
+++ b/src/weles/agent/dispatch.py
@@ -1,10 +1,13 @@
 import inspect
+import logging
 from collections.abc import Callable
 from typing import Any, NamedTuple
 
 from langsmith import traceable
 
 from weles.utils.errors import MaxToolCallsError, ToolNotFoundError
+
+log = logging.getLogger(__name__)
 
 
 class ToolResult(NamedTuple):
@@ -23,12 +26,25 @@ class ToolRegistry:
         self._handlers[name] = handler
         self._schemas[name] = schema
 
+    def _truncate_inputs(self, tool_name: str, tool_input: dict[str, Any]) -> dict[str, Any]:
+        schema = self._schemas.get(tool_name, {})
+        props = schema.get("properties", {})
+        result = dict(tool_input)
+        for field, spec in props.items():
+            max_len = spec.get("maxLength")
+            val = result.get(field)
+            if max_len and isinstance(val, str) and len(val) > max_len:
+                log.warning("tool=%s field=%s truncated %d→%d", tool_name, field, len(val), max_len)
+                result[field] = val[:max_len]
+        return result
+
     def dispatch(self, tool_name: str, tool_input: dict[str, Any]) -> ToolResult:
         if tool_name not in self._handlers:
             raise ToolNotFoundError(f"Unknown tool: {tool_name!r}")
         if self._call_count >= self._max_calls:
             raise MaxToolCallsError(f"Research limit reached (max {self._max_calls})")
         self._call_count += 1
+        tool_input = self._truncate_inputs(tool_name, tool_input)
         result = self._handlers[tool_name](tool_input)
         if isinstance(result, ToolResult):
             return result
@@ -42,6 +58,7 @@ class ToolRegistry:
         if self._call_count >= self._max_calls:
             raise MaxToolCallsError(f"Research limit reached (max {self._max_calls})")
         self._call_count += 1
+        tool_input = self._truncate_inputs(tool_name, tool_input)
         result = self._handlers[tool_name](tool_input)
         if inspect.isawaitable(result):
             result = await result

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
 from weles.agent.client import get_client
@@ -96,7 +96,7 @@ def evict_session(session_id: str) -> None:
 
 
 class MessageBody(BaseModel):
-    content: str
+    content: str = Field(..., max_length=32_000)
 
 
 def _get_session(session_id: str) -> dict[str, Any]:

--- a/src/weles/tools/history_tools.py
+++ b/src/weles/tools/history_tools.py
@@ -11,10 +11,12 @@ ADD_TO_HISTORY_SCHEMA: dict[str, Any] = {
     "properties": {
         "item_name": {
             "type": "string",
+            "maxLength": 200,
             "description": "Name of the item (e.g. 'Red Wing 875', 'creatine monohydrate').",
         },
         "category": {
             "type": "string",
+            "maxLength": 200,
             "description": "Item category (e.g. footwear, supplement, exercise).",
         },
         "domain": {
@@ -35,6 +37,7 @@ ADD_TO_HISTORY_SCHEMA: dict[str, Any] = {
         },
         "notes": {
             "type": "string",
+            "maxLength": 1000,
             "description": "Optional notes about the item.",
         },
     },

--- a/src/weles/tools/profile_tools.py
+++ b/src/weles/tools/profile_tools.py
@@ -34,6 +34,7 @@ SAVE_PROFILE_FIELD_SCHEMA: dict[str, Any] = {
         },
         "value": {
             "type": "string",
+            "maxLength": 500,
             "description": "New value for the field.",
         },
     },
@@ -65,10 +66,12 @@ UPDATE_PREFERENCE_SCHEMA: dict[str, Any] = {
         },
         "value": {
             "type": "string",
+            "maxLength": 1000,
             "description": "Preference value (e.g. 'No minimalist styles', 'Avoids whey protein').",
         },
         "reason": {
             "type": "string",
+            "maxLength": 1000,
             "description": "Optional: what the user said or did that prompted this preference.",
         },
     },

--- a/src/weles/tools/reddit.py
+++ b/src/weles/tools/reddit.py
@@ -158,7 +158,7 @@ async def search_reddit(
 SEARCH_REDDIT_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "query": {"type": "string", "description": "Search query."},
+        "query": {"type": "string", "maxLength": 500, "description": "Search query."},
         "subcategory": {
             "type": "string",
             "description": (

--- a/src/weles/tools/web.py
+++ b/src/weles/tools/web.py
@@ -116,7 +116,7 @@ async def search_web(query: str, limit: int = 8) -> list[WebResult]:
 SEARCH_WEB_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "query": {"type": "string", "description": "Search query."},
+        "query": {"type": "string", "maxLength": 500, "description": "Search query."},
         "limit": {
             "type": "integer",
             "default": 8,

--- a/tests/integration/test_message_limits.py
+++ b/tests/integration/test_message_limits.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.mark.usefixtures("mock_claude")
+def test_content_too_long_returns_422(client):
+    resp = client.post(
+        "/sessions",
+        json={"mode": "general"},
+    )
+    assert resp.status_code == 201
+    session_id = resp.json()["id"]
+
+    resp = client.post(
+        f"/sessions/{session_id}/messages",
+        json={"content": "x" * 33_000},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.usefixtures("mock_claude")
+def test_content_at_limit_accepted(client):
+    resp = client.post(
+        "/sessions",
+        json={"mode": "general"},
+    )
+    assert resp.status_code == 201
+    session_id = resp.json()["id"]
+
+    with client.stream(
+        "POST",
+        f"/sessions/{session_id}/messages",
+        json={"content": "x" * 32_000},
+    ) as resp:
+        assert resp.status_code == 200

--- a/tests/unit/test_tool_schemas.py
+++ b/tests/unit/test_tool_schemas.py
@@ -1,0 +1,27 @@
+import pytest
+
+from weles.tools.history_tools import ADD_TO_HISTORY_SCHEMA
+from weles.tools.profile_tools import SAVE_PROFILE_FIELD_SCHEMA, UPDATE_PREFERENCE_SCHEMA
+from weles.tools.reddit import SEARCH_REDDIT_SCHEMA
+from weles.tools.web import SEARCH_WEB_SCHEMA
+
+
+@pytest.mark.parametrize(
+    "schema, field",
+    [
+        (ADD_TO_HISTORY_SCHEMA, "item_name"),
+        (ADD_TO_HISTORY_SCHEMA, "category"),
+        (ADD_TO_HISTORY_SCHEMA, "notes"),
+        (SAVE_PROFILE_FIELD_SCHEMA, "value"),
+        (UPDATE_PREFERENCE_SCHEMA, "value"),
+        (UPDATE_PREFERENCE_SCHEMA, "reason"),
+        (SEARCH_REDDIT_SCHEMA, "query"),
+        (SEARCH_WEB_SCHEMA, "query"),
+    ],
+)
+def test_schema_has_max_length(schema, field):
+    props = schema.get("properties", {})
+    assert field in props, f"Field {field!r} not found in schema"
+    assert "maxLength" in props[field], f"Field {field!r} missing maxLength"
+    assert isinstance(props[field]["maxLength"], int)
+    assert props[field]["maxLength"] > 0


### PR DESCRIPTION
## Summary

- `MessageBody.content` is now capped at 32,000 chars via Pydantic `Field(max_length=...)` — oversized payloads get HTTP 422
- Added `maxLength` to all string fields in tool JSON schemas (`item_name`/`category`: 200, `notes`/`value`/`reason`: 1000, `query`: 500, profile `value`: 500)
- `dispatch.py` truncates any string inputs exceeding `maxLength` with a log warning as a safety net (Claude won't exceed schema limits, but truncation guards against future schema drift)

## Checklist

- [x] `MessageBody` rejects `content` > 32,000 chars with HTTP 422
- [x] `maxLength` present on all named tool string fields
- [x] Truncation safety net in `dispatch._truncate_inputs()` applied in both `dispatch()` and `adispatch()`
- [x] `tests/integration/test_message_limits.py` — 422 on oversize, 200 at limit
- [x] `tests/unit/test_tool_schemas.py` — all fields have `maxLength`
- [x] `CHANGELOG.md` updated
- [x] `make lint` passes
- [x] `make test` passes (excluding pre-existing `test_fitness_mode.py` import error)

## Notes

`test_fitness_mode.py` fails to import `weles.research.programs` — that module was deleted on `main` before this branch. Pre-existing issue, not introduced here.