### PR TITLE
feat: #81 Backend robustness — compression timeout and exception handling

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - History and preference context blocks are wrapped in `<untrusted_data>` tags; system prompt instructs Claude to treat them as data, never as instructions (#79)
 - Newlines stripped from `item_name`, `category`, and `notes` at write time in `add_to_history_handler` (#79)
 - `update_profile()` no longer uses an f-string SQL interpolation; column names now resolved via `_PROFILE_COLUMN_MAP` and pre-built `_UPDATE_SQLS` dict (#80)
+- Compression API call now has a 30 s timeout; `APITimeoutError` is caught separately from generic exceptions; both log at ERROR with traceback (#81)
+- QC search failures in `session_start.py` now log at ERROR instead of WARNING (#81)
+- `_get_user_country()` in `web.py` now logs a WARNING when profile fetch fails (#81)
 
 ### v0.1 — Skeleton
 

--- a/src/weles/agent/compression.py
+++ b/src/weles/agent/compression.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 from typing import Any
 
@@ -7,6 +8,8 @@ from anthropic.types import TextBlock
 
 from weles.agent.session import CONTEXT_WINDOW, Session, estimated_tokens
 from weles.db.connection import get_db
+
+logger = logging.getLogger(__name__)
 
 _PROTECTED_TAIL = 10  # last N messages are never compressed
 
@@ -64,13 +67,19 @@ async def maybe_compress_context(
                     model=model,
                     max_tokens=256,
                     messages=[{"role": "user", "content": p}],
+                    timeout=30.0,
                 )
 
             try:
                 resp = await loop.run_in_executor(None, _call)
                 first = resp.content[0] if resp.content else None
                 summary = first.text if isinstance(first, TextBlock) else f"{u_text} / {a_text}"
+            except anthropic.APITimeoutError:
+                logger.error("Compression timed out for session %s", session_id, exc_info=True)
+                i += 2
+                continue
             except Exception:
+                logger.error("Compression failed for session %s", session_id, exc_info=True)
                 i += 2
                 continue
 

--- a/src/weles/api/session_start.py
+++ b/src/weles/api/session_start.py
@@ -189,7 +189,7 @@ async def run_proactive_checks(
                 limit=5,
             )
         except Exception:
-            logger.warning("QC search failed for %s", item_name)
+            logger.error("QC search failed for %s", item_name, exc_info=True)
             continue
 
         found = False

--- a/src/weles/tools/web.py
+++ b/src/weles/tools/web.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Any, TypedDict
 from urllib.parse import urlparse
@@ -7,6 +8,8 @@ import httpx
 from weles.agent.dispatch import ToolResult
 from weles.utils.paths import resource_path
 
+logger = logging.getLogger(__name__)
+
 
 def _get_user_country() -> str | None:
     """Return the user's country from the profile, or None."""
@@ -15,6 +18,7 @@ def _get_user_country() -> str | None:
 
         return get_profile().country
     except Exception:
+        logger.warning("Failed to fetch user profile for country lookup", exc_info=True)
         return None
 
 

--- a/tests/unit/test_compression.py
+++ b/tests/unit/test_compression.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
+import anthropic
 import pytest
 
 from weles.agent.compression import maybe_compress_context
@@ -118,3 +119,41 @@ async def test_compression_uses_id_not_content(tmp_db: object) -> None:
     ).fetchone()
     assert pair2_user["is_compressed"] == 0
     assert pair2_user["content"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_compression_continues_on_api_timeout(tmp_db: object) -> None:
+    """Compression task continues and logs ERROR when APITimeoutError is raised."""
+    from unittest.mock import patch
+
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    session_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO sessions (id, title, mode, created_at) VALUES (?, NULL, 'general', ?)",
+        (session_id, datetime.utcnow()),
+    )
+    conn.commit()
+
+    pairs = [("question", "answer")] * 10
+    ids = _insert_messages(conn, session_id, pairs)
+
+    session = _make_session_from_db(session_id)
+
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = anthropic.APITimeoutError(request=MagicMock())
+
+    with (
+        patch("weles.agent.compression.needs_compression", return_value=True),
+        patch("weles.agent.compression.logger") as mock_logger,
+    ):
+        await maybe_compress_context(session_id, mock_client, session)
+
+    mock_logger.error.assert_called()
+    call_args = mock_logger.error.call_args_list
+    assert any("timed out" in str(args[0]) for args, _ in call_args)
+    first_msg = conn.execute(
+        "SELECT is_compressed FROM messages WHERE id = ?", (ids[0],)
+    ).fetchone()
+    assert first_msg["is_compressed"] == 0


### PR DESCRIPTION
## Summary

- `compression.py`: `client.messages.create()` now has `timeout=30.0`; `APITimeoutError` is caught separately from generic `Exception`; both branches log at `ERROR` with `exc_info=True` and continue to the next pair
- `session_start.py`: QC search `except Exception` now logs at `ERROR` (was `WARNING`)
- `tools/web.py`: `_get_user_country()` now logs a `WARNING` with `exc_info=True` instead of silently returning `None`

## Checklist

- [x] `compression.py` timeout=30.0 on `messages.create()`
- [x] `APITimeoutError` caught specifically; both timeout and generic exception log at ERROR
- [x] `session_start.py` QC search failure logs at ERROR
- [x] `web.py` profile fetch failure logs WARNING
- [x] `tests/unit/test_compression.py` — APITimeoutError does not crash; ERROR is logged; message remains uncompressed
- [x] `CHANGELOG.md` updated
- [x] `make lint` passes
- [x] `make test` passes