### PR TITLE
feat: #92 Async file I/O — cache prompt files at module load

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Compression API call now has a 30 s timeout; `APITimeoutError` is caught separately from generic exceptions; both log at ERROR with traceback (#81)
 - QC search failures in `session_start.py` now log at ERROR instead of WARNING (#81)
 - `_get_user_country()` in `web.py` now logs a WARNING when profile fetch fails (#81)
+- Prompt and config files (`system.md`, mode prompts, `research.md`, `programs.toml`) are now cached at module load; `build_system_prompt()` and `stream_response()` make zero blocking file reads per request (#92)
 
 ### v0.1 — Skeleton
 

--- a/src/weles/agent/prompts.py
+++ b/src/weles/agent/prompts.py
@@ -5,6 +5,13 @@ from weles.profile.context import build_profile_block
 from weles.profile.models import Preference, UserProfile
 from weles.utils.paths import resource_path
 
+_SYSTEM_TEXT: str = resource_path("src/weles/prompts/system.md").read_text(encoding="utf-8")
+_RESEARCH_TEXT: str = resource_path("src/weles/prompts/research.md").read_text(encoding="utf-8")
+_MODE_TEXTS: dict[str, str] = {
+    mode: resource_path(f"src/weles/prompts/modes/{mode}.md").read_text(encoding="utf-8")
+    for mode in ("shopping", "diet", "fitness", "lifestyle")
+}
+
 
 def _load_programs_text() -> str:
     path = resource_path("config/programs.toml")
@@ -22,6 +29,8 @@ def _load_programs_text() -> str:
     return "\n".join(lines)
 
 
+_PROGRAMS_TEXT: str = _load_programs_text()
+
 _VALID_MODES = {"general", "shopping", "diet", "fitness", "lifestyle"}
 
 
@@ -36,14 +45,11 @@ def build_system_prompt(
     blocks: list[dict[str, Any]] = []
 
     # Block 1: base system prompt (always present)
-    system_text = resource_path("src/weles/prompts/system.md").read_text(encoding="utf-8")
-    blocks.append({"type": "text", "text": system_text})
+    blocks.append({"type": "text", "text": _SYSTEM_TEXT})
 
     # Block 2: mode addendum + optional hard constraints + research guidelines (skipped for general)
     if mode != "general":
-        mode_text = resource_path(f"src/weles/prompts/modes/{mode}.md").read_text(encoding="utf-8")
-        research_text = resource_path("src/weles/prompts/research.md").read_text(encoding="utf-8")
-        combined = mode_text
+        combined = _MODE_TEXTS[mode]
         if mode == "diet" and profile and profile.dietary_restrictions:
             constraint = (
                 f"Hard constraints: user cannot eat {profile.dietary_restrictions}. "
@@ -52,14 +58,14 @@ def build_system_prompt(
             )
             combined = combined + "\n\n" + constraint
         if mode == "fitness":
-            combined = combined + "\n\n" + _load_programs_text()
+            combined = combined + "\n\n" + _PROGRAMS_TEXT
             if profile and profile.injury_history:
                 combined = (
                     combined
                     + "\n\nFlag if any recommended program includes movements that may"
                     + f" conflict with: {profile.injury_history}."
                 )
-        blocks.append({"type": "text", "text": combined + "\n\n" + research_text})
+        blocks.append({"type": "text", "text": combined + "\n\n" + _RESEARCH_TEXT})
 
     # Block 3: profile context (omitted when profile is empty and no preferences)
     profile_text = build_profile_block(profile or UserProfile(), preferences or [])

--- a/src/weles/agent/stream.py
+++ b/src/weles/agent/stream.py
@@ -50,7 +50,7 @@ class DoneEvent:
 AgentEvent = TextDeltaEvent | ToolStartEvent | ToolEndEvent | ToolErrorEvent | DoneEvent
 
 _RESEARCH_TOOLS = {"search_reddit", "search_web"}
-_RESEARCH_PROMPT_PATH = "src/weles/prompts/research.md"
+_RESEARCH_GUIDANCE: str = resource_path("src/weles/prompts/research.md").read_text(encoding="utf-8")
 
 
 def _build_description(tool_name: str, tool_input: dict[str, Any]) -> str:
@@ -176,8 +176,7 @@ async def stream_response(
         user_content: list[dict[str, Any]] = list(tool_results)
 
         if not research_guidance_injected and any(t.name in _RESEARCH_TOOLS for t in tool_uses):
-            guidance = resource_path(_RESEARCH_PROMPT_PATH).read_text(encoding="utf-8")
-            user_content.append({"type": "text", "text": guidance})
+            user_content.append({"type": "text", "text": _RESEARCH_GUIDANCE})
             research_guidance_injected = True
 
         failure_msg = _build_failure_message(failed_tools)

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from weles.agent.prompts import build_system_prompt
@@ -30,3 +32,10 @@ def test_non_empty_profile_adds_third_block() -> None:
 def test_empty_profile_does_not_add_third_block() -> None:
     blocks = build_system_prompt("shopping", UserProfile(), [])
     assert len(blocks) == 2
+
+
+def test_build_system_prompt_does_not_read_files_on_repeated_calls() -> None:
+    with patch("pathlib.Path.read_text") as mock_read:
+        build_system_prompt("shopping", None, [])
+        build_system_prompt("diet", None, [])
+    mock_read.assert_not_called()


### PR DESCRIPTION
## Summary

- `prompts.py`: `system.md`, `research.md`, all four mode prompts, and `programs.toml` are now read once at import time into module-level constants (`_SYSTEM_TEXT`, `_RESEARCH_TEXT`, `_MODE_TEXTS`, `_PROGRAMS_TEXT`). `build_system_prompt()` reads from cache only.
- `stream.py`: `research.md` is now cached as `_RESEARCH_GUIDANCE` at module load; the per-turn `read_text()` call is removed.

## Checklist

- [x] All `read_text()` calls inside `build_system_prompt()` removed; replaced with module-level constants
- [x] `stream.py` research guidance cached at module load
- [x] `programs.toml` load also cached at module load via `_PROGRAMS_TEXT`
- [x] `tests/unit/test_prompts.py` — `Path.read_text` not called during two `build_system_prompt()` invocations
- [x] `CHANGELOG.md` updated
- [x] `make lint` passes
- [x] `make test` passes