### PR TITLE
feat: #82 TypeScript types — Settings interface, UserProfile accessor

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `_get_user_country()` in `web.py` now logs a WARNING when profile fetch fails (#81)
 - Prompt and config files (`system.md`, mode prompts, `research.md`, `programs.toml`) are now cached at module load; `build_system_prompt()` and `stream_response()` make zero blocking file reads per request (#92)
 
+### v1.2 — UX
+
+#### Changed
+- Defined `Settings` interface in `types.ts`; `getSettings()` and `patchSettings()` are now fully typed; settings state in `SettingsPage` uses `Settings` instead of `Record<string, unknown>` (#82)
+- Added `[key: string]: unknown` index signature to `UserProfile`; removed double `as unknown as Record<string, string | null>` cast in `InformationPage` (#82)
+
 ### v0.1 — Skeleton
 
 #### Added

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { clearData, createSession, deleteHistoryItem, deletePreference, deleteSession, getProfile, getSessionMessages, getSettings, listHistory, listPreferences, listSessions, patchProfile, patchSession, patchSettings } from './api'
-import type { ChatMessage, HistoryItem, Mode, Preference, Session, ToolProgress, UserProfile } from './types'
+import type { ChatMessage, HistoryItem, Mode, Preference, Session, Settings, ToolProgress, UserProfile } from './types'
 import './App.css'
 
 const MODES: Mode[] = ['general', 'shopping', 'diet', 'fitness', 'lifestyle']
@@ -32,8 +32,15 @@ const DECAY_DEFAULTS: Record<string, number> = {
   taste_lifestyle: 365,
 }
 
+const DEFAULT_SETTINGS: Settings = {
+  follow_up_cadence: 'off',
+  proactive_surfacing: 'false',
+  max_tool_calls_per_turn: 6,
+  decay_thresholds: {},
+}
+
 function SettingsPage({ onBack }: { onBack: () => void }) {
-  const [settings, setSettings] = useState<Record<string, unknown>>({})
+  const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS)
   const [confirmClear, setConfirmClear] = useState(false)
   const [decayDraft, setDecayDraft] = useState<Record<string, number>>(DECAY_DEFAULTS)
   const [settingsLoaded, setSettingsLoaded] = useState(false)
@@ -42,13 +49,13 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
   useEffect(() => {
     getSettings().then(s => {
       setSettings(s)
-      const fromServer = (s.decay_thresholds as Record<string, number>) ?? {}
+      const fromServer = s.decay_thresholds ?? {}
       setDecayDraft({ ...DECAY_DEFAULTS, ...fromServer })
       setSettingsLoaded(true)
     }).catch(() => setError('Failed to load settings — try refreshing'))
   }, [])
 
-  async function save(patch: Record<string, unknown>) {
+  async function save(patch: Partial<Settings>) {
     const updated = await patchSettings(patch)
     setSettings(updated)
   }
@@ -56,7 +63,7 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
   async function saveDecay() {
     const updated = await patchSettings({ decay_thresholds: decayDraft })
     setSettings(updated)
-    const fromServer = (updated.decay_thresholds as Record<string, number>) ?? {}
+    const fromServer = updated.decay_thresholds ?? {}
     setDecayDraft({ ...DECAY_DEFAULTS, ...fromServer })
   }
 
@@ -92,8 +99,8 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
         <label>
           <input
             type="checkbox"
-            checked={settings.proactive_surfacing === 'true' || settings.proactive_surfacing === true}
-            onChange={e => save({ proactive_surfacing: String(e.target.checked) })}
+            checked={settings.proactive_surfacing === 'true'}
+            onChange={e => save({ proactive_surfacing: (String(e.target.checked) as 'true' | 'false') })}
           />
           Suggest relevant information proactively
         </label>
@@ -262,7 +269,7 @@ function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHist
         setProfile(p)
         setPrefs(pr)
         setHistory(hPage.items)
-        setThresholds((s.decay_thresholds as DecayThresholds) ?? {})
+        setThresholds(s.decay_thresholds ?? {})
       }
     ).catch(() => setError('Failed to load — try refreshing'))
   }, [])
@@ -303,7 +310,7 @@ function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHist
             <ProfileField
               key={field}
               field={field}
-              value={(profile as unknown as Record<string, string | null>)[field]}
+              value={profile[field] as string | null}
               timestamp={timestamps[field] ?? null}
               stale={isStale(field, timestamps, thresholds)}
               onSave={saveField}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { HistoryItem, Mode, Preference, Session, UserProfile } from './types'
+import type { HistoryItem, Mode, Preference, Session, Settings, UserProfile } from './types'
 
 function checkOk(r: Response): Response {
   if (!r.ok) throw new Error(`HTTP ${r.status}`)
@@ -28,12 +28,12 @@ export async function patchSession(id: string, patch: { title?: string; mode?: M
   return checkOk(r).json()
 }
 
-export async function getSettings(): Promise<Record<string, unknown>> {
+export async function getSettings(): Promise<Settings> {
   const r = await fetch('/settings')
   return checkOk(r).json()
 }
 
-export async function patchSettings(patch: Record<string, unknown>): Promise<Record<string, unknown>> {
+export async function patchSettings(patch: Partial<Settings>): Promise<Settings> {
   const r = await fetch('/settings', {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
@@ -103,4 +103,4 @@ export async function deleteHistoryItem(id: string): Promise<void> {
   await fetch(`/history/${id}`, { method: 'DELETE' })
 }
 
-export type { HistoryItem, Preference, UserProfile } from './types'
+export type { HistoryItem, Preference, Settings, UserProfile } from './types'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,12 @@
 export type Mode = 'general' | 'shopping' | 'diet' | 'fitness' | 'lifestyle'
 
+export interface Settings {
+  follow_up_cadence: 'weekly' | 'monthly' | 'off'
+  proactive_surfacing: 'true' | 'false'
+  max_tool_calls_per_turn: number
+  decay_thresholds: Record<string, number>
+}
+
 export interface Session {
   id: string
   title: string | null
@@ -33,6 +40,7 @@ export interface ChatMessage {
 }
 
 export interface UserProfile {
+  [key: string]: unknown
   id: number | null
   height_cm: number | null
   weight_kg: number | null


### PR DESCRIPTION
## Summary

- `Settings` interface defined in `types.ts` with precise field types (`follow_up_cadence`, `proactive_surfacing` as `'true' | 'false'`, `max_tool_calls_per_turn`, `decay_thresholds`)
- `getSettings()` returns `Promise<Settings>`; `patchSettings()` accepts `Partial<Settings>` and returns `Promise<Settings>`
- `UserProfile` gets `[key: string]: unknown` index signature; double `as unknown as Record<string, string | null>` cast in `InformationPage` is replaced with `profile[field] as string | null`
- `SettingsPage` settings state updated to `Settings` with a typed default; `decay_thresholds` casts removed from both `SettingsPage` and `InformationPage`

**Note on `proactive_surfacing`:** The backend stores and returns this as the string `"true"` or `"false"` (not a boolean), so the interface uses `'true' | 'false'` rather than `boolean` for accuracy. The App.tsx comparison is simplified from `=== 'true' || === true` to `=== 'true'`.

## Checklist

- [x] `Settings` interface defined in `types.ts`
- [x] `getSettings()` and `patchSettings()` use `Settings`
- [x] `UserProfile` index signature added
- [x] Double cast removed from `InformationPage`
- [x] `tsc --noEmit` passes with zero errors
- [x] `CHANGELOG.md` updated