### PR TITLE
feat: #83 Accessibility pass — labels, keyboard navigation, focus management

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### v1.2 — UX
 
+#### Added
+- `aria-label` on all icon buttons: delete session, remove preference, delete history item, back to chat, new chat (#83)
+- Visually-hidden `<label>` for chat textarea; `id="chat-input"` added for programmatic association (#83)
+- Session list items converted to `role="button"` divs with `tabIndex={0}` and `onKeyDown` for Enter/Space; keyboard users can now navigate and select sessions (#83)
+- Confirm-clear modal now has `role="alertdialog" aria-modal="true"`; focus moves to Confirm button when modal opens (#83)
+- Global `:focus-visible` outline (`2px solid #7a7aff`) in `App.css`; `.sr-only` utility class added (#83)
+- Settings, Information, and History pages focus their `<h1>` on mount for screen reader page-transition announcements (#83)
+
 #### Changed
 - Defined `Settings` interface in `types.ts`; `getSettings()` and `patchSettings()` are now fully typed; settings state in `SettingsPage` uses `Settings` instead of `Record<string, unknown>` (#82)
 - Added `[key: string]: unknown` index signature to `UserProfile`; removed double `as unknown as Record<string, string | null>` cast in `InformationPage` (#82)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,19 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
+*:focus-visible { outline: 2px solid #7a7aff; outline-offset: 2px; }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 body {
   font-family: system-ui, sans-serif;
   background: #0f0f0f;
@@ -54,6 +68,10 @@ body {
   cursor: pointer;
   font-size: 13px;
   color: #aaa;
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
 }
 .session-item:hover { background: #222; color: #e8e8e8; }
 .session-item.active { background: #252525; color: #e8e8e8; }
@@ -190,7 +208,7 @@ body {
   line-height: 1.4;
   max-height: 200px;
 }
-.input-bar textarea:focus { outline: none; border-color: #555; }
+.input-bar textarea:focus { border-color: #555; }
 .input-bar button {
   background: #2a4a7a;
   color: #e8e8e8;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,11 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
   const [decayDraft, setDecayDraft] = useState<Record<string, number>>(DECAY_DEFAULTS)
   const [settingsLoaded, setSettingsLoaded] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const headingRef = useRef<HTMLHeadingElement>(null)
+  const confirmBtnRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => { headingRef.current?.focus() }, [])
+  useEffect(() => { if (confirmClear) confirmBtnRef.current?.focus() }, [confirmClear])
 
   useEffect(() => {
     getSettings().then(s => {
@@ -72,12 +77,12 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
     onBack()
   }
 
-  if (error) return <div className="settings-page"><button className="back-btn" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
+  if (error) return <div className="settings-page"><button className="back-btn" aria-label="Back to chat" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
 
   return (
     <div className="settings-page">
-      <button className="back-btn" onClick={onBack}>← Back</button>
-      <h1>Settings</h1>
+      <button className="back-btn" aria-label="Back to chat" onClick={onBack}>← Back</button>
+      <h1 ref={headingRef} tabIndex={-1}>Settings</h1>
 
       <section>
         <h2>Notifications</h2>
@@ -124,9 +129,9 @@ function SettingsPage({ onBack }: { onBack: () => void }) {
       <section>
         <h2>Data</h2>
         {confirmClear ? (
-          <div className="confirm-modal">
-            <p>This will permanently delete all sessions, history, profile, and preferences. Cannot be undone.</p>
-            <button onClick={handleClearData}>Confirm</button>
+          <div className="confirm-modal" role="alertdialog" aria-modal="true" aria-labelledby="confirm-title">
+            <p id="confirm-title">This will permanently delete all sessions, history, profile, and preferences. Cannot be undone.</p>
+            <button ref={confirmBtnRef} onClick={handleClearData}>Confirm</button>
             <button onClick={() => setConfirmClear(false)}>Cancel</button>
           </div>
         ) : (
@@ -262,6 +267,9 @@ function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHist
   const [history, setHistory] = useState<HistoryItem[]>([])
   const [thresholds, setThresholds] = useState<DecayThresholds>({})
   const [error, setError] = useState<string | null>(null)
+  const headingRef = useRef<HTMLHeadingElement>(null)
+
+  useEffect(() => { headingRef.current?.focus() }, [])
 
   useEffect(() => {
     Promise.all([getProfile(), listPreferences(), listHistory(), getSettings()]).then(
@@ -295,13 +303,13 @@ function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHist
     historySummary[item.domain][item.status] = (historySummary[item.domain][item.status] ?? 0) + 1
   }
 
-  if (error) return <div className="info-page"><button className="back-btn" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
-  if (!profile) return <div className="info-page"><button className="back-btn" onClick={onBack}>← Back</button><p>Loading…</p></div>
+  if (error) return <div className="info-page"><button className="back-btn" aria-label="Back to chat" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
+  if (!profile) return <div className="info-page"><button className="back-btn" aria-label="Back to chat" onClick={onBack}>← Back</button><p>Loading…</p></div>
 
   return (
     <div className="info-page">
-      <button className="back-btn" onClick={onBack}>← Back</button>
-      <h1>Information</h1>
+      <button className="back-btn" aria-label="Back to chat" onClick={onBack}>← Back</button>
+      <h1 ref={headingRef} tabIndex={-1}>Information</h1>
 
       {INFO_SECTIONS.map(section => (
         <section key={section.title} className="info-section">
@@ -329,7 +337,7 @@ function InformationPage({ onBack, onGoHistory }: { onBack: () => void; onGoHist
               <span className="info-pref-value">{pref.value}</span>
               {pref.reason && <span className="info-pref-reason">{pref.reason}</span>}
               <span className={`info-pref-source source-${pref.source}`}>{pref.source}</span>
-              <button className="del-btn" onClick={() => handleDeletePref(pref.id)}>×</button>
+              <button className="del-btn" aria-label="Remove preference" onClick={() => handleDeletePref(pref.id)}>×</button>
             </div>
           ))
         }
@@ -368,7 +376,10 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
   const [domain, setDomain] = useState('')
   const [status, setStatus] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const headingRef = useRef<HTMLHeadingElement>(null)
   const LIMIT = 50
+
+  useEffect(() => { headingRef.current?.focus() }, [])
 
   useEffect(() => {
     setItems([])
@@ -393,12 +404,12 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
     setTotal(prev => prev - 1)
   }
 
-  if (error) return <div className="history-page"><button className="back-btn" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
+  if (error) return <div className="history-page"><button className="back-btn" aria-label="Back to chat" onClick={onBack}>← Back</button><p className="page-error">{error}</p></div>
 
   return (
     <div className="history-page">
-      <button className="back-btn" onClick={onBack}>← Back</button>
-      <h1>History</h1>
+      <button className="back-btn" aria-label="Back to chat" onClick={onBack}>← Back</button>
+      <h1 ref={headingRef} tabIndex={-1}>History</h1>
       <div className="history-filters">
         <label>
           Domain
@@ -437,7 +448,7 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
                   <td>{item.status}</td>
                   <td>{item.rating != null ? `${item.rating}/5` : '—'}</td>
                   <td>{item.created_at.slice(0, 10)}</td>
-                  <td><button className="del-btn" onClick={() => handleDelete(item.id)}>×</button></td>
+                  <td><button className="del-btn" aria-label="Delete history item" onClick={() => handleDelete(item.id)}>×</button></td>
                 </tr>
               ))}
             </tbody>
@@ -654,16 +665,19 @@ export default function App() {
     <div className="layout">
       {/* Sidebar */}
       <aside className="sidebar">
-        <button className="new-chat-btn" onClick={newChat}>+ New chat</button>
+        <button className="new-chat-btn" aria-label="New chat" onClick={newChat}>+ New chat</button>
         <nav className="session-list">
           {sessions.map(s => (
             <div
               key={s.id}
               className={`session-item${s.id === activeId ? ' active' : ''}`}
+              role="button"
+              tabIndex={0}
               onClick={() => selectSession(s.id)}
+              onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectSession(s.id) } }}
             >
               <span className="session-title">{s.title ?? s.preview ?? 'New chat'}</span>
-              <button className="del-btn" onClick={e => removeSession(s.id, e)}>×</button>
+              <button className="del-btn" aria-label="Delete session" onClick={e => removeSession(s.id, e)}>×</button>
             </div>
           ))}
         </nav>
@@ -728,7 +742,9 @@ export default function App() {
 
         {/* Input */}
         <div className="input-bar">
+          <label htmlFor="chat-input" className="sr-only">Message</label>
           <textarea
+            id="chat-input"
             ref={inputRef}
             value={input}
             onChange={e => setInput(e.target.value)}

--- a/tests/integration/test_history_pagination.py
+++ b/tests/integration/test_history_pagination.py
@@ -1,4 +1,5 @@
 """Integration tests: GET /history pagination."""
+
 import uuid
 from datetime import datetime
 

--- a/tests/integration/test_indices.py
+++ b/tests/integration/test_indices.py
@@ -1,4 +1,5 @@
 """Integration test: all expected indices exist after alembic upgrade head."""
+
 from weles.db.connection import get_db
 
 EXPECTED_INDICES = {

--- a/tests/integration/test_messages_pagination.py
+++ b/tests/integration/test_messages_pagination.py
@@ -1,4 +1,5 @@
 """Integration tests: GET /sessions/{id}/messages pagination."""
+
 import uuid
 from datetime import datetime, timedelta
 

--- a/tests/unit/test_session_cache.py
+++ b/tests/unit/test_session_cache.py
@@ -1,4 +1,5 @@
 """Tests for LRU session cache in messages router."""
+
 import pytest
 
 import weles.api.routers.messages as messages_mod


### PR DESCRIPTION
## Summary
- Added `aria-label` to all icon buttons (delete session, remove preference, delete history item, back to chat, new chat)
- Session list items: `role="button"` + `tabIndex={0}` + `onKeyDown` for Enter/Space keyboard activation
- Confirm-clear modal: `role="alertdialog" aria-modal="true"`; focus auto-moves to Confirm button on open
- Chat textarea gets `id="chat-input"` + visually-hidden `<label htmlFor="chat-input">Message</label>`
- Settings/Information/History pages focus their `<h1>` on mount for screen reader page announcements
- `App.css`: global `*:focus-visible` outline (`2px solid #7a7aff`); `.sr-only` utility class; removed `outline: none` from textarea focus rule

## Acceptance criteria
- [x] All `×` buttons have correct `aria-label` per context
- [x] Back button: `aria-label="Back to chat"`
- [x] New chat button: `aria-label="New chat"`
- [x] Textarea: `id="chat-input"` + `.sr-only` label
- [x] Session list: keyboard-activatable via Enter/Space
- [x] Confirm modal: `role="alertdialog" aria-modal="true"`; focus on Confirm button when opened
- [x] Global `:focus-visible` outline in `App.css`
- [x] `.sr-only` utility class added
- [x] Page transition focuses heading on mount

## Test plan
- [ ] Tab through session list — each session reachable, Enter/Space selects it
- [ ] Screen reader announces icon buttons correctly
- [ ] Confirm-clear modal traps focus on open
- [ ] Focus ring visible on all interactive elements (keyboard navigation only)
- [ ] Switching to Settings/Information/History moves focus to page heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)