### PR TITLE
feat: #84 History page — text search and date sort

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `_get_user_country()` in `web.py` now logs a WARNING when profile fetch fails (#81)
 - Prompt and config files (`system.md`, mode prompts, `research.md`, `programs.toml`) are now cached at module load; `build_system_prompt()` and `stream_response()` make zero blocking file reads per request (#92)
 
+### v2.0 — Features
+
+#### Added
+- `GET /history` accepts `search` (case-insensitive substring on `item_name`) and `sort` (`newest`|`oldest`) query params (#84)
+- History page: search-by-name input (300ms debounce) and sort dropdown; composes with existing domain/status filters (#84)
+
 ### v1.2 — UX
 
 #### Added

--- a/docs/api.md
+++ b/docs/api.md
@@ -159,6 +159,8 @@ List history items, most recent first, with pagination.
 **Query params** (all optional):
 - `domain`: `shopping|diet|fitness|lifestyle`
 - `status`: `recommended|bought|tried|rated|skipped`
+- `search`: substring match on `item_name` (case-insensitive)
+- `sort`: `newest` (default) | `oldest` — controls `created_at` sort order
 - `limit`: items per page (default `50`)
 - `offset`: number of items to skip (default `0`)
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -294,7 +294,7 @@ body {
 .history-page h1 { margin-bottom: 24px; }
 .history-filters { display: flex; gap: 16px; margin-bottom: 20px; }
 .history-filters label { display: flex; align-items: center; gap: 8px; font-size: 14px; }
-.history-filters select {
+.history-filters select, .history-search {
   background: #1e1e1e;
   border: 1px solid #333;
   color: #e8e8e8;
@@ -302,6 +302,7 @@ body {
   padding: 4px 8px;
   font-size: 13px;
 }
+.history-search { min-width: 180px; }
 .history-empty { color: #666; font-size: 14px; }
 .history-table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .history-table th {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -375,6 +375,9 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
   const [offset, setOffset] = useState(0)
   const [domain, setDomain] = useState('')
   const [status, setStatus] = useState('')
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [sort, setSort] = useState<'newest' | 'oldest'>('newest')
   const [error, setError] = useState<string | null>(null)
   const headingRef = useRef<HTMLHeadingElement>(null)
   const LIMIT = 50
@@ -382,17 +385,22 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
   useEffect(() => { headingRef.current?.focus() }, [])
 
   useEffect(() => {
+    const t = setTimeout(() => setSearch(searchInput), 300)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  useEffect(() => {
     setItems([])
     setOffset(0)
     setTotal(0)
-    listHistory(domain || undefined, status || undefined, LIMIT, 0)
+    listHistory(domain || undefined, status || undefined, LIMIT, 0, search || undefined, sort)
       .then(page => { setItems(page.items); setTotal(page.total) })
       .catch(() => setError('Failed to load — try refreshing'))
-  }, [domain, status])
+  }, [domain, status, search, sort])
 
   async function loadMore() {
     const nextOffset = offset + LIMIT
-    const page = await listHistory(domain || undefined, status || undefined, LIMIT, nextOffset)
+    const page = await listHistory(domain || undefined, status || undefined, LIMIT, nextOffset, search || undefined, sort)
     setItems(prev => [...prev, ...page.items])
     setOffset(nextOffset)
     setTotal(page.total)
@@ -412,6 +420,16 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
       <h1 ref={headingRef} tabIndex={-1}>History</h1>
       <div className="history-filters">
         <label>
+          Search by name
+          <input
+            type="search"
+            className="history-search"
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            placeholder="e.g. Sony WH-1000XM5"
+          />
+        </label>
+        <label>
           Domain
           <select value={domain} onChange={e => setDomain(e.target.value)}>
             {DOMAINS.map(d => <option key={d} value={d}>{d || 'All'}</option>)}
@@ -421,6 +439,13 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
           Status
           <select value={status} onChange={e => setStatus(e.target.value)}>
             {STATUSES.map(s => <option key={s} value={s}>{s || 'All'}</option>)}
+          </select>
+        </label>
+        <label>
+          Sort
+          <select value={sort} onChange={e => setSort(e.target.value as 'newest' | 'oldest')}>
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
           </select>
         </label>
       </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -82,10 +82,14 @@ export async function listHistory(
   status?: string,
   limit = 50,
   offset = 0,
+  search?: string,
+  sort: 'newest' | 'oldest' = 'newest',
 ): Promise<HistoryPage> {
   const params = new URLSearchParams()
   if (domain) params.set('domain', domain)
   if (status) params.set('status', status)
+  if (search) params.set('search', search)
+  params.set('sort', sort)
   params.set('limit', String(limit))
   params.set('offset', String(offset))
   const r = await fetch(`/history?${params.toString()}`)

--- a/src/weles/api/routers/history.py
+++ b/src/weles/api/routers/history.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException
 
@@ -11,10 +11,14 @@ router = APIRouter(tags=["history"])
 async def list_history(
     domain: str | None = None,
     status: str | None = None,
+    search: str | None = None,
+    sort: Literal["newest", "oldest"] = "newest",
     limit: int = 50,
     offset: int = 0,
 ) -> dict[str, Any]:
-    return get_history(domain=domain, status=status, limit=limit, offset=offset)
+    return get_history(
+        domain=domain, status=status, search=search, sort=sort, limit=limit, offset=offset
+    )
 
 
 @router.delete("/history/{item_id}", status_code=204)

--- a/src/weles/db/history_repo.py
+++ b/src/weles/db/history_repo.py
@@ -16,6 +16,8 @@ _STATUS_PREFIX: dict[str, str] = {
 def get_history(
     domain: str | None = None,
     status: str | None = None,
+    search: str | None = None,
+    sort: str = "newest",
     limit: int = 50,
     offset: int = 0,
 ) -> dict[str, Any]:
@@ -29,10 +31,14 @@ def get_history(
     if status:
         filters.append("status = ?")
         params.append(status)
+    if search:
+        filters.append("LOWER(item_name) LIKE LOWER(?)")
+        params.append(f"%{search}%")
     where = (" WHERE " + " AND ".join(filters)) if filters else ""
+    order = "ASC" if sort == "oldest" else "DESC"
     total: int = conn.execute(f"SELECT COUNT(*) {base}{where}", params).fetchone()[0]
     rows = conn.execute(
-        f"SELECT * {base}{where} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+        f"SELECT * {base}{where} ORDER BY created_at {order} LIMIT ? OFFSET ?",
         params + [limit, offset],
     ).fetchall()
     return {

--- a/tests/integration/test_history_search.py
+++ b/tests/integration/test_history_search.py
@@ -1,0 +1,76 @@
+"""Integration tests: GET /history search and sort params."""
+
+import uuid
+from datetime import datetime, timedelta
+
+from weles.db.connection import get_db
+
+
+def _insert(
+    conn,
+    item_name: str,
+    domain: str = "shopping",
+    status: str = "recommended",
+    created_at: datetime | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO history (id, item_name, category, domain, status, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        (str(uuid.uuid4()), item_name, "audio", domain, status, created_at or datetime.utcnow()),
+    )
+    conn.commit()
+
+
+def test_search_filters_by_name(client) -> None:
+    conn = get_db()
+    _insert(conn, "Sony WH-1000XM5")
+    _insert(conn, "Bose QC45")
+    r = client.get("/history?search=sony")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["items"][0]["item_name"] == "Sony WH-1000XM5"
+
+
+def test_search_is_case_insensitive(client) -> None:
+    conn = get_db()
+    _insert(conn, "Sony WH-1000XM5")
+    _insert(conn, "Bose QC45")
+    r = client.get("/history?search=SONY")
+    assert r.status_code == 200
+    assert r.json()["total"] == 1
+    assert r.json()["items"][0]["item_name"] == "Sony WH-1000XM5"
+
+
+def test_sort_oldest_returns_ascending(client) -> None:
+    conn = get_db()
+    now = datetime.utcnow()
+    _insert(conn, "Old item", created_at=now - timedelta(days=10))
+    _insert(conn, "New item", created_at=now)
+    r = client.get("/history?sort=oldest")
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert len(items) >= 2
+    assert items[0]["item_name"] == "Old item"
+
+
+def test_search_composes_with_domain(client) -> None:
+    conn = get_db()
+    _insert(conn, "Sony WH-1000XM5", domain="shopping")
+    _insert(conn, "Sony protein bar", domain="diet")
+    r = client.get("/history?search=sony&domain=shopping")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["items"][0]["domain"] == "shopping"
+
+
+def test_search_composes_with_status(client) -> None:
+    conn = get_db()
+    _insert(conn, "Sony WH-1000XM5", status="recommended")
+    _insert(conn, "Sony LinkBuds", status="bought")
+    r = client.get("/history?search=sony&status=bought")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["items"][0]["item_name"] == "Sony LinkBuds"


### PR DESCRIPTION
## Summary
- `GET /history` now accepts `search` (case-insensitive LOWER/LIKE substring on `item_name`) and `sort` (`newest`|`oldest`) query params alongside existing `domain`, `status`, `limit`, `offset`
- Frontend: search-by-name input with 300ms debounce + sort dropdown added to History page; both compose with existing filters
- `docs/api.md` updated with new params

## Acceptance criteria
- [x] `search` filters by `item_name` case-insensitively via `LOWER(item_name) LIKE LOWER(?)`
- [x] `sort=oldest` returns `ORDER BY created_at ASC`; `sort=newest` (default) is `DESC`
- [x] Params compose with `domain`, `status`, `limit`, `offset`
- [x] Frontend: search input (300ms debounce), sort dropdown, clearing re-fetches
- [x] 5 integration tests in `tests/integration/test_history_search.py`
- [x] `docs/api.md` updated

## Test plan
- [ ] Type in search field — results filter after 300ms
- [ ] Clear search — all items reappear
- [ ] Switch to "Oldest first" — oldest item appears at top
- [ ] Combine search + domain filter — only matching domain items shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)