### PR TITLE
feat: #85 Session search in sidebar

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### v2.0 — Features
 
 #### Added
+- `GET /sessions` accepts `search` param; filters by case-insensitive title substring; sessions with `null` title excluded (#85)
+- Sidebar: session search input with 300ms debounce; shows "No sessions match" when search returns empty (#85)
 - `GET /history` accepts `search` (case-insensitive substring on `item_name`) and `sort` (`newest`|`oldest`) query params (#84)
 - History page: search-by-name input (300ms debounce) and sort dropdown; composes with existing domain/status filters (#84)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -47,6 +47,9 @@ Create a new chat session. Runs session-start checks.
 ### `GET /sessions`
 List all sessions, most recent first.
 
+**Query params** (optional):
+- `search`: substring match on `title` (case-insensitive); sessions with `null` title are excluded from search results
+
 **Response `200`** — array of:
 ```json
 {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -51,6 +51,17 @@ body {
 }
 .new-chat-btn:hover { background: #333; }
 
+.session-search {
+  background: #1a1a1a;
+  border: 1px solid #2e2e2e;
+  color: #e8e8e8;
+  border-radius: 5px;
+  padding: 5px 8px;
+  font-size: 12px;
+  width: 100%;
+}
+.session-search::placeholder { color: #555; }
+
 .session-list {
   flex: 1;
   overflow-y: auto;
@@ -58,6 +69,8 @@ body {
   flex-direction: column;
   gap: 2px;
 }
+
+.session-empty { color: #555; font-size: 12px; padding: 6px 8px; font-style: italic; }
 
 .session-item {
   display: flex;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -499,12 +499,23 @@ export default function App() {
   const [toolsExpanded, setToolsExpanded] = useState(false)
   const [page, setPage] = useState<'chat' | 'settings' | 'info' | 'history'>('chat')
   const [mode, setMode] = useState<Mode>('general')
+  const [sessionSearchInput, setSessionSearchInput] = useState('')
+  const [sessionSearch, setSessionSearch] = useState('')
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     listSessions().then(setSessions)
   }, [])
+
+  useEffect(() => {
+    const t = setTimeout(() => setSessionSearch(sessionSearchInput), 300)
+    return () => clearTimeout(t)
+  }, [sessionSearchInput])
+
+  useEffect(() => {
+    listSessions(sessionSearch || undefined).then(setSessions)
+  }, [sessionSearch])
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -691,20 +702,31 @@ export default function App() {
       {/* Sidebar */}
       <aside className="sidebar">
         <button className="new-chat-btn" aria-label="New chat" onClick={newChat}>+ New chat</button>
+        <input
+          type="search"
+          className="session-search"
+          placeholder="Search sessions…"
+          aria-label="Search sessions"
+          value={sessionSearchInput}
+          onChange={e => setSessionSearchInput(e.target.value)}
+        />
         <nav className="session-list">
-          {sessions.map(s => (
-            <div
-              key={s.id}
-              className={`session-item${s.id === activeId ? ' active' : ''}`}
-              role="button"
-              tabIndex={0}
-              onClick={() => selectSession(s.id)}
-              onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectSession(s.id) } }}
-            >
-              <span className="session-title">{s.title ?? s.preview ?? 'New chat'}</span>
-              <button className="del-btn" aria-label="Delete session" onClick={e => removeSession(s.id, e)}>×</button>
-            </div>
-          ))}
+          {sessions.length === 0 && sessionSearch
+            ? <p className="session-empty">No sessions match</p>
+            : sessions.map(s => (
+              <div
+                key={s.id}
+                className={`session-item${s.id === activeId ? ' active' : ''}`}
+                role="button"
+                tabIndex={0}
+                onClick={() => selectSession(s.id)}
+                onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectSession(s.id) } }}
+              >
+                <span className="session-title">{s.title ?? s.preview ?? 'New chat'}</span>
+                <button className="del-btn" aria-label="Delete session" onClick={e => removeSession(s.id, e)}>×</button>
+              </div>
+            ))
+          }
         </nav>
         <div className="sidebar-links">
           <button onClick={() => setPage('info')}>Information</button>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -10,8 +10,9 @@ export async function createSession(): Promise<Session> {
   return checkOk(r).json()
 }
 
-export async function listSessions(): Promise<Session[]> {
-  const r = await fetch('/sessions')
+export async function listSessions(search?: string): Promise<Session[]> {
+  const url = search ? `/sessions?search=${encodeURIComponent(search)}` : '/sessions'
+  const r = await fetch(url)
   return checkOk(r).json()
 }
 

--- a/src/weles/api/routers/sessions.py
+++ b/src/weles/api/routers/sessions.py
@@ -58,14 +58,20 @@ async def create_session() -> dict[str, Any]:
 
 
 @router.get("")
-async def list_sessions() -> list[dict[str, Any]]:
+async def list_sessions(search: str | None = None) -> list[dict[str, Any]]:
     conn = get_db()
-    rows = conn.execute("SELECT * FROM sessions ORDER BY created_at DESC").fetchall()
+    if search:
+        rows = conn.execute(
+            "SELECT * FROM sessions WHERE title IS NOT NULL AND LOWER(title) LIKE LOWER(?)"
+            " ORDER BY created_at DESC",
+            (f"%{search}%",),
+        ).fetchall()
+    else:
+        rows = conn.execute("SELECT * FROM sessions ORDER BY created_at DESC").fetchall()
     result = []
     for row in rows:
         d = dict(row)
         d["preview"] = _session_preview(d["id"])
-        d["created_at"] = d["created_at"]
         result.append(d)
     return result
 

--- a/tests/integration/test_session_search.py
+++ b/tests/integration/test_session_search.py
@@ -1,0 +1,55 @@
+"""Integration tests: GET /sessions?search= param."""
+
+
+def test_search_filters_by_title(client) -> None:
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    # Create two sessions with known titles
+    r1 = client.post("/sessions")
+    r2 = client.post("/sessions")
+    sid1, sid2 = r1.json()["id"], r2.json()["id"]
+    conn.execute("UPDATE sessions SET title = ? WHERE id = ?", ("Running shoes advice", sid1))
+    conn.execute("UPDATE sessions SET title = ? WHERE id = ?", ("Diet plan", sid2))
+    conn.commit()
+
+    r = client.get("/sessions?search=running")
+    assert r.status_code == 200
+    ids = [s["id"] for s in r.json()]
+    assert sid1 in ids
+    assert sid2 not in ids
+
+
+def test_search_is_case_insensitive(client) -> None:
+    from weles.db.connection import get_db
+
+    conn = get_db()
+    r1 = client.post("/sessions")
+    sid1 = r1.json()["id"]
+    conn.execute("UPDATE sessions SET title = ? WHERE id = ?", ("Running shoes advice", sid1))
+    conn.commit()
+
+    r = client.get("/sessions?search=RUNNING")
+    assert r.status_code == 200
+    ids = [s["id"] for s in r.json()]
+    assert sid1 in ids
+
+
+def test_empty_search_returns_all(client) -> None:
+    client.post("/sessions")
+    client.post("/sessions")
+
+    r_all = client.get("/sessions")
+    r_empty = client.get("/sessions?search=")
+    assert r_all.status_code == 200
+    assert r_empty.status_code == 200
+    assert len(r_all.json()) == len(r_empty.json())
+
+
+def test_search_excludes_null_titles(client) -> None:
+    # A brand-new session has title=null; it should not appear in search results
+    client.post("/sessions")
+    r = client.get("/sessions?search=new")
+    assert r.status_code == 200
+    for s in r.json():
+        assert s["title"] is not None


### PR DESCRIPTION
## Summary
- `GET /sessions` accepts optional `search` query param: filters by `LOWER(title) LIKE LOWER(?)`, excluding null-title sessions
- Sidebar: search input below "New chat" with `aria-label="Search sessions"`, 300ms debounce, "No sessions match" empty state
- `docs/api.md` updated

## Acceptance criteria
- [x] `GET /sessions?search=running` returns only sessions whose title contains "running" (case-insensitive)
- [x] Sessions with `null` title excluded from search results
- [x] Empty/absent `search` returns all sessions (unchanged behaviour)
- [x] Frontend: search input with `placeholder="Search sessions…"` and `aria-label="Search sessions"`
- [x] 300ms debounce; clear re-fetches all sessions
- [x] "No sessions match" shown when search returns empty
- [x] 4 integration tests in `tests/integration/test_session_search.py`
- [x] `docs/api.md` updated

## Test plan
- [ ] Type in sidebar search — session list filters after 300ms
- [ ] Clear search — all sessions reappear
- [ ] "No sessions match" shown for a term that matches nothing
- [ ] New (untitled) sessions don't appear in search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)