### PR TITLE
feat: #90 Mode-switching context — acknowledge mode change in conversation

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### v2.0 — Features
 
 #### Added
+- Mode-switch notice injected into the conversation when mode changes mid-session; `[System: Mode changed to {mode}]` prepended to the next user message so Claude reframes context (#90)
 - Cross-domain product instruction added to `system.md`: agent draws on subreddits from all relevant domains regardless of current mode (#89)
 - `[cross_domain]` section added to `config/subreddits.toml` with r/BuyItForLife, r/Frugal, r/personalfinance (#89)
 - Profile conflict resolution instruction added to `system.md`: agent treats explicit user self-reports as authoritative and immediately calls `save_profile_field` (#88)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -168,6 +168,17 @@ body {
 .message.user { justify-content: flex-end; }
 .message.assistant { justify-content: flex-start; }
 
+.mode-switch-notice {
+  text-align: center;
+  font-size: 12px;
+  color: #666;
+  padding: 4px 12px;
+  border-top: 1px solid #2e2e2e;
+  border-bottom: 1px solid #2e2e2e;
+  background: #141414;
+  font-style: italic;
+}
+
 .bubble {
   max-width: 70%;
   padding: 10px 14px;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -509,6 +509,7 @@ export default function App() {
   const [mode, setMode] = useState<Mode>('general')
   const [sessionSearchInput, setSessionSearchInput] = useState('')
   const [sessionSearch, setSessionSearch] = useState('')
+  const [pendingModeSwitch, setPendingModeSwitch] = useState<Mode | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
@@ -605,6 +606,10 @@ export default function App() {
     if (activeId) {
       await patchSession(activeId, { mode: newMode })
       setSessions(prev => prev.map(s => s.id === activeId ? { ...s, mode: newMode } : s))
+      if (messages.length > 0) {
+        setMessages(prev => [...prev, { id: `ms-${Date.now()}`, role: 'assistant', content: newMode, type: 'mode_switch' }])
+        setPendingModeSwitch(newMode)
+      }
     }
   }
 
@@ -621,10 +626,12 @@ export default function App() {
     const assistantId = `a-${Date.now()}`
     setMessages(prev => [...prev, { id: assistantId, role: 'assistant', content: '', streaming: true }])
 
+    const modeSwitch = pendingModeSwitch
+    setPendingModeSwitch(null)
     const resp = await fetch(`/sessions/${sessionId}/messages`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content: userMsg.content }),
+      body: JSON.stringify({ content: userMsg.content, mode_changed_to: modeSwitch }),
     })
 
     if (!resp.body) {
@@ -776,15 +783,24 @@ export default function App() {
               Load older messages
             </button>
           )}
-          {messages.map(msg => (
-            <div key={msg.id} className={`message ${msg.role}`}>
-              <div className="bubble">
-                {msg.role === 'assistant'
-                  ? <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content || (msg.streaming ? '…' : '')}</ReactMarkdown>
-                  : msg.content}
+          {messages.map(msg => {
+            if (msg.type === 'mode_switch') {
+              return (
+                <div key={msg.id} className="mode-switch-notice">
+                  Mode switched to {MODE_LABELS[msg.content as Mode] ?? msg.content}. Prior context from this session is still available.
+                </div>
+              )
+            }
+            return (
+              <div key={msg.id} className={`message ${msg.role}`}>
+                <div className="bubble">
+                  {msg.role === 'assistant'
+                    ? <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content || (msg.streaming ? '…' : '')}</ReactMarkdown>
+                    : msg.content}
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
           <div ref={bottomRef} />
         </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,6 +37,7 @@ export interface ChatMessage {
   role: 'user' | 'assistant'
   content: string
   streaming?: boolean
+  type?: 'mode_switch'
 }
 
 export interface UserProfile {

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -97,6 +97,7 @@ def evict_session(session_id: str) -> None:
 
 class MessageBody(BaseModel):
     content: str = Field(..., max_length=32_000)
+    mode_changed_to: str | None = None
 
 
 def _get_session(session_id: str) -> dict[str, Any]:
@@ -160,7 +161,10 @@ async def post_message(session_id: str, body: MessageBody, request: Request) -> 
     async def event_stream() -> AsyncIterator[dict[str, Any]]:
         is_first = _is_first_message(session_id)
 
-        _save_message(session_id, "user", body.content)
+        user_content = body.content
+        if body.mode_changed_to:
+            user_content = f"[System: Mode changed to {body.mode_changed_to}]\n{body.content}"
+        _save_message(session_id, "user", user_content)
         _set_session_title(session_id, body.content)
 
         if is_first:

--- a/tests/integration/test_mode_switch.py
+++ b/tests/integration/test_mode_switch.py
@@ -1,0 +1,47 @@
+"""Integration tests: mode switch system note injection."""
+
+
+def test_mode_switch_note_injected_in_user_turn(client, mock_claude) -> None:
+    session = client.post("/sessions").json()
+    sid = session["id"]
+
+    # First message in general mode (no note)
+    client.post(
+        f"/sessions/{sid}/messages",
+        json={"content": "Hello"},
+        headers={"Accept": "text/event-stream"},
+    )
+
+    # Patch to diet mode
+    client.patch(f"/sessions/{sid}", json={"mode": "diet"})
+
+    # Second message with mode_changed_to
+    client.post(
+        f"/sessions/{sid}/messages",
+        json={"content": "What should I eat?", "mode_changed_to": "diet"},
+        headers={"Accept": "text/event-stream"},
+    )
+
+    # Fetch messages from DB via API
+    msgs = client.get(f"/sessions/{sid}/messages").json()
+    user_messages = [m for m in msgs if m["role"] == "user"]
+    assert len(user_messages) == 2
+
+    second_user = user_messages[1]["content"]
+    assert "[System: Mode changed to diet]" in second_user
+    assert "What should I eat?" in second_user
+
+
+def test_no_mode_switch_note_when_field_absent(client, mock_claude) -> None:
+    session = client.post("/sessions").json()
+    sid = session["id"]
+
+    client.post(
+        f"/sessions/{sid}/messages",
+        json={"content": "Hello"},
+        headers={"Accept": "text/event-stream"},
+    )
+
+    msgs = client.get(f"/sessions/{sid}/messages").json()
+    user_messages = [m for m in msgs if m["role"] == "user"]
+    assert "[System: Mode changed to" not in user_messages[0]["content"]


### PR DESCRIPTION
## Summary
- `MessageBody` gains optional `mode_changed_to: str | None` field
- When set, backend prepends `[System: Mode changed to {mode}]` to the saved user message content (session title still derived from original content)
- Frontend: `changeMode()` injects a `type: 'mode_switch'` notice into the message list and sets `pendingModeSwitch` state; next `sendMessage()` sends `mode_changed_to` and clears state
- `ChatMessage` type gains `type?: 'mode_switch'` discriminant; rendered as `.mode-switch-notice` styled div

## Acceptance criteria
- [x] Mode-switch notice shown in chat UI when mode changes mid-session
- [x] Notice not shown for new sessions with no prior messages
- [x] Next user message after mode switch has `[System: Mode changed to {mode}]` prepended
- [x] Injection is one-shot (state cleared after send)
- [x] 2 integration tests in `tests/integration/test_mode_switch.py`

## Test plan
- [ ] Switch from General to Diet mid-session — notice appears in chat
- [ ] Send a message — notice disappears from pending state (not shown again on next switch-less send)
- [ ] Switch mode with no prior messages — no notice shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)