### PR TITLE
feat: #91 Inline profile editing from chat — quick-edit affordance

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,91 @@
+You are starting a work session on the Weles project. Follow these steps exactly, in order.
+
+---
+
+## Step 1 — Status check
+
+Run these in parallel:
+- `gh pr list --repo RAGNAROS-HS/Weles --state open` — open PRs (in-progress work)
+- `gh issue list --repo RAGNAROS-HS/Weles --state open --limit 50` — open issues
+
+Then check which open issues are **unblocked**: an issue is unblocked when all issues listed in its "Dependencies:" line are closed. To check an issue's dependencies, read its body via `gh issue view {number} --repo RAGNAROS-HS/Weles`.
+
+Present a concise status report:
+
+```
+Open PRs (in progress):
+  #N  branch-name  "PR title"
+
+Next unblocked issues:
+  #N  "Issue title"  [labels]
+  #N  "Issue title"  [labels]
+  ...
+
+Suggested next issue: #N — "title"
+Reason: lowest unblocked issue; all dependencies closed.
+```
+
+Pick up the suggested (lowest-numbered unblocked) issue automatically and proceed to Step 2.
+
+---
+
+## Step 2 — Read the issue
+
+1. Run `gh issue view {number} --repo RAGNAROS-HS/Weles` to read the full issue body.
+2. Read `CLAUDE.md` for any rules that apply to this issue.
+3. If the issue modifies the API, read `docs/api.md`. If it touches core patterns, read `docs/architecture.md`.
+4. State back in one short paragraph: what you're about to build, the key constraints, and what tests you'll write. No hand-waving — be specific.
+
+Proceed immediately to Step 3 — do not wait for confirmation.
+
+---
+
+## Step 3 — Implement
+
+1. Create branch: `git checkout -b feat/issue-{N}-{slug}` where slug is 3–5 words from the title, hyphenated.
+2. Implement the acceptance criteria from the issue — nothing more. Do not refactor adjacent code.
+3. Write the tests listed under "Tests shipped with this issue".
+4. Update docs:
+   - `CHANGELOG.md` — add entries under `[Unreleased]` in the correct milestone section.
+   - `docs/api.md` — if any endpoint was added or changed.
+   - `docs/architecture.md` — if any core pattern, module, or invariant changed.
+5. Run `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/` for lint, and `uv run pytest tests/ -q` for tests. Fix any failures before continuing. Do not skip or suppress.
+
+---
+
+## Step 4 — Create the PR
+
+1. Stage and commit all changes:
+   - Commit message format: `feat: #N {issue title}` (subject ≤72 chars)
+   - Body only if the why isn't obvious from the title.
+2. Push the branch: `git push -u origin feat/issue-{N}-{slug}`
+3. Create the PR:
+   - Title: `feat: #N {issue title}`
+   - Body: fill out `.github/pull_request_template.md` — acceptance criteria checklist items checked off, docs checkboxes checked, notes on anything non-obvious.
+   - Use `gh pr create --repo RAGNAROS-HS/Weles --title "..." --body "..." --base main`
+4. Output the PR URL.
+
+---
+
+## Step 5 — Wait for Qodo review
+
+After outputting the PR URL, call `ScheduleWakeup` with `delaySeconds: 600` and `reason: "waiting for Qodo to review PR #{N}"`. Pass the literal sentinel `<<autonomous-loop-dynamic>>` as the `prompt` field so the session resumes automatically.
+
+When the wakeup fires, fetch comments:
+
+```
+gh pr view {N} --repo RAGNAROS-HS/Weles --comments
+gh api repos/RAGNAROS-HS/Weles/pulls/{N}/comments
+```
+
+---
+
+## Step 6 — Address review feedback
+
+For each Qodo comment:
+
+1. **Evaluate** whether the issue is a real bug, false positive, or out of scope for this issue. Dismiss false positives with a brief reason.
+2. **Fix** every real bug, correctness issue, or security issue. Do not fix style suggestions or speculative improvements.
+3. After all fixes: run lint and tests again (same commands as Step 3 step 5). Fix any new failures.
+4. Commit all fixes in a single commit: `fix: address Qodo review issues on PR #{N}`
+5. Push: `git push`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### v2.0 — Features
 
 #### Added
+- Inline profile edit chips appear after `save_profile_field` or `update_preference` tool calls; clicking [Edit] lets users correct the saved value in-place (#91)
+- `tool_end` SSE payload now includes `field` and `value` keys for `save_profile_field` and `update_preference` (additive, non-breaking) (#91)
 - Mode-switch notice injected into the conversation when mode changes mid-session; `[System: Mode changed to {mode}]` prepended to the next user message so Claude reframes context (#90)
 - Cross-domain product instruction added to `system.md`: agent draws on subreddits from all relevant domains regardless of current mode (#89)
 - `[cross_domain]` section added to `config/subreddits.toml` with r/BuyItForLife, r/Frugal, r/personalfinance (#89)

--- a/docs/api.md
+++ b/docs/api.md
@@ -97,6 +97,8 @@ SSE event types:
 event: text_delta     data: {"delta": "..."}
 event: tool_start     data: {"tool": "search_reddit", "description": "Searching r/BuyItForLife..."}
 event: tool_end       data: {"tool": "search_reddit", "result_summary": "Found 8 posts"}
+                      # for save_profile_field / update_preference, also includes:
+                      # "field": "fitness_level", "value": "intermediate"
 event: tool_error     data: {"tool": "search_reddit", "error": "Request timed out"}
 event: done           data: {"session_id": "uuid", "title": "string"}
 event: error          data: {"message": "Claude API unavailable"}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -347,5 +347,18 @@ body {
 
 .load-more-btn { margin-top: 12px; background: #1e1e1e; border: 1px solid #333; color: #ccc; padding: 8px 20px; border-radius: 6px; cursor: pointer; font-size: 13px; }
 .load-more-btn:hover { background: #2a2a2a; }
+
+/* ── Profile edit chip ── */
+.profile-edit-chip {
+  display: flex; align-items: center; gap: 6px;
+  padding: 5px 16px; background: #141414; border-top: 1px solid #2e2e2e;
+  font-size: 12px; color: #888;
+}
+.chip-icon { color: #666; }
+.chip-label { color: #aaa; }
+.chip-edit-btn { background: none; border: none; color: #6a9fca; cursor: pointer; font-size: 12px; padding: 0; }
+.chip-edit-btn:hover { color: #8abfea; }
+.chip-input { background: #222; border: 1px solid #444; color: #e8e8e8; border-radius: 4px; padding: 2px 6px; font-size: 12px; }
+.chip-btn { background: #2a2a2a; border: 1px solid #3a3a3a; color: #e8e8e8; border-radius: 4px; padding: 2px 8px; cursor: pointer; font-size: 12px; }
 .load-older-btn { display: block; margin: 0 auto 12px; background: transparent; border: 1px solid #333; color: #888; padding: 6px 16px; border-radius: 6px; cursor: pointer; font-size: 12px; }
 .load-older-btn:hover { color: #ccc; border-color: #555; }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -495,6 +495,45 @@ function HistoryPage({ onBack }: { onBack: () => void }) {
   )
 }
 
+// ── Profile edit chip ─────────────────────────────────────────────────────────
+
+function ProfileEditChip({ tool, field, value }: { tool: string; field: string; value: string }) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [saved, setSaved] = useState(value)
+
+  async function handleSave() {
+    if (draft.trim() === saved) { setEditing(false); return }
+    await patchProfile({ [field]: draft.trim() || null })
+    setSaved(draft.trim())
+    setEditing(false)
+  }
+
+  const label = tool === 'update_preference' ? `preference: ${field}` : field
+
+  return (
+    <div className="profile-edit-chip">
+      <span className="chip-icon">✎</span>
+      <span className="chip-label">Saved: {label} = {saved}</span>
+      {editing ? (
+        <>
+          <input
+            className="chip-input"
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') handleSave(); if (e.key === 'Escape') setEditing(false) }}
+            autoFocus
+          />
+          <button className="chip-btn" onClick={handleSave}>OK</button>
+          <button className="chip-btn" onClick={() => setEditing(false)}>✕</button>
+        </>
+      ) : (
+        <button className="chip-edit-btn" onClick={() => setEditing(true)}>[Edit]</button>
+      )}
+    </div>
+  )
+}
+
 // ── Chat page ────────────────────────────────────────────────────────────────
 
 export default function App() {
@@ -677,7 +716,13 @@ export default function App() {
             setToolProgress(prev => [...prev, { tool: payload.tool, status: 'running', description: payload.description }])
           } else if (currentEvent === 'tool_end') {
             setToolProgress(prev =>
-              prev.map(t => t.tool === payload.tool ? { ...t, status: 'done', summary: payload.result_summary } : t)
+              prev.map(t => t.tool === payload.tool ? {
+                ...t,
+                status: 'done',
+                summary: payload.result_summary,
+                ...(payload.field != null ? { field: payload.field as string } : {}),
+                ...(payload.value != null ? { value: payload.value as string } : {}),
+              } : t)
             )
           } else if (currentEvent === 'tool_error') {
             setToolProgress(prev =>
@@ -821,6 +866,10 @@ export default function App() {
             }
           </div>
         )}
+        {/* Profile edit chips — ephemeral, shown only for the current turn */}
+        {toolProgress.filter(t => t.status === 'done' && t.field && t.value !== undefined && (t.tool === 'save_profile_field' || t.tool === 'update_preference')).map((t, i) => (
+          <ProfileEditChip key={i} tool={t.tool} field={t.field!} value={t.value!} />
+        ))}
 
         {/* Input */}
         <div className="input-bar">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,6 +30,8 @@ export interface ToolProgress {
   description?: string
   summary?: string
   error?: string
+  field?: string
+  value?: string
 }
 
 export interface ChatMessage {

--- a/src/weles/agent/stream.py
+++ b/src/weles/agent/stream.py
@@ -34,6 +34,8 @@ class ToolStartEvent:
 class ToolEndEvent:
     tool: str
     result_summary: str
+    field: str | None = None
+    value: str | None = None
 
 
 @dataclass
@@ -136,7 +138,16 @@ async def stream_response(
             yield ToolStartEvent(tool=tool_use.name, description=description)
             try:
                 result = await registry.adispatch(tool_use.name, tool_use.input)
-                yield ToolEndEvent(tool=tool_use.name, result_summary=result.summary)
+                end_event = ToolEndEvent(tool=tool_use.name, result_summary=result.summary)
+                if tool_use.name == "save_profile_field":
+                    f = tool_use.input.get("field")
+                    end_event.field = str(f) if f is not None else None
+                    end_event.value = str(tool_use.input.get("value", ""))
+                elif tool_use.name == "update_preference":
+                    d = tool_use.input.get("dimension")
+                    end_event.field = str(d) if d is not None else None
+                    end_event.value = str(tool_use.input.get("value", ""))
+                yield end_event
                 result_content = str(result.data)
             except MaxToolCallsError:
                 yield ToolErrorEvent(tool="max_tool_calls", error="Research limit reached")

--- a/src/weles/api/routers/messages.py
+++ b/src/weles/api/routers/messages.py
@@ -297,10 +297,12 @@ def _agent_event_to_sse(event: AgentEvent, title: str, session_id: str) -> dict[
             "data": json.dumps({"tool": event.tool, "description": event.description}),
         }
     if isinstance(event, ToolEndEvent):
-        return {
-            "event": "tool_end",
-            "data": json.dumps({"tool": event.tool, "result_summary": event.result_summary}),
-        }
+        payload: dict[str, Any] = {"tool": event.tool, "result_summary": event.result_summary}
+        if event.field is not None:
+            payload["field"] = event.field
+        if event.value is not None:
+            payload["value"] = event.value
+        return {"event": "tool_end", "data": json.dumps(payload)}
     if isinstance(event, ToolErrorEvent):
         return {
             "event": "tool_error",

--- a/tests/integration/test_profile_chip_payload.py
+++ b/tests/integration/test_profile_chip_payload.py
@@ -1,0 +1,83 @@
+"""Integration tests: tool_end SSE payload includes field and value for profile tools."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from anthropic.types import RawContentBlockDeltaEvent, RawMessageStopEvent, TextDelta, ToolUseBlock
+
+from weles.agent.stream import ToolEndEvent
+from weles.api.routers.messages import _agent_event_to_sse
+
+
+def test_tool_end_sse_includes_field_and_value_for_save_profile_field() -> None:
+    event = ToolEndEvent(
+        tool="save_profile_field",
+        result_summary="Saved fitness_level = intermediate",
+        field="fitness_level",
+        value="intermediate",
+    )
+    sse = _agent_event_to_sse(event, "title", "sid")
+    assert sse is not None
+    payload = json.loads(sse["data"])
+    assert payload["field"] == "fitness_level"
+    assert payload["value"] == "intermediate"
+
+
+def test_tool_end_sse_no_field_for_regular_tools() -> None:
+    event = ToolEndEvent(tool="search_reddit", result_summary="Found 5 posts")
+    sse = _agent_event_to_sse(event, "title", "sid")
+    assert sse is not None
+    payload = json.loads(sse["data"])
+    assert "field" not in payload
+    assert "value" not in payload
+
+
+@pytest.mark.asyncio
+async def test_stream_response_emits_field_value_for_save_profile_field(tmp_db) -> None:
+    from weles.agent.dispatch import ToolRegistry
+    from weles.agent.stream import ToolEndEvent, stream_response
+    from weles.tools.profile_tools import SAVE_PROFILE_FIELD_SCHEMA, save_profile_field_handler
+
+    tool_input = {"field": "fitness_level", "value": "intermediate"}
+
+    first_stream = MagicMock()
+    first_stream.__enter__ = MagicMock(return_value=first_stream)
+    first_stream.__exit__ = MagicMock(return_value=False)
+    first_stream.__iter__ = MagicMock(return_value=iter([]))
+    first_message = MagicMock()
+    first_message.stop_reason = "tool_use"
+    first_message.content = [
+        ToolUseBlock(id="tu_1", name="save_profile_field", input=tool_input, type="tool_use")
+    ]
+    first_stream.get_final_message = MagicMock(return_value=first_message)
+
+    text_event = RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=0,
+        delta=TextDelta(type="text_delta", text="Updated."),
+    )
+    second_stream = MagicMock()
+    second_stream.__enter__ = MagicMock(return_value=second_stream)
+    second_stream.__exit__ = MagicMock(return_value=False)
+    stop = RawMessageStopEvent(type="message_stop")
+    second_stream.__iter__ = MagicMock(return_value=iter([text_event, stop]))
+    second_message = MagicMock()
+    second_message.stop_reason = "end_turn"
+    second_message.content = []
+    second_stream.get_final_message = MagicMock(return_value=second_message)
+
+    mock_client = MagicMock()
+    mock_client.messages.stream.side_effect = [first_stream, second_stream]
+
+    registry = ToolRegistry()
+    registry.register("save_profile_field", save_profile_field_handler, SAVE_PROFILE_FIELD_SCHEMA)
+
+    events = []
+    async for event in stream_response(mock_client, [], [], [], registry):
+        events.append(event)
+
+    tool_end_events = [e for e in events if isinstance(e, ToolEndEvent)]
+    assert len(tool_end_events) == 1
+    assert tool_end_events[0].field == "fitness_level"
+    assert tool_end_events[0].value == "intermediate"


### PR DESCRIPTION
## Summary
- `ToolEndEvent` gains optional `field: str | None` and `value: str | None` fields
- `stream.py`: after `save_profile_field` / `update_preference` dispatch, extracts field/dimension + value from `tool_use.input` and attaches to `ToolEndEvent`
- `messages.py` `_agent_event_to_sse`: includes `field`/`value` in `tool_end` payload when set (additive, non-breaking)
- Frontend `ToolProgress` type gains `field?` and `value?`; SSE handler captures them on `tool_end`
- `ProfileEditChip` component: shows "✎ Saved: {field} = {value} [Edit]" chip; clicking [Edit] opens inline input, calls `PATCH /profile`, updates displayed value
- Chips rendered below the tool strip for the current turn only; ephemeral (cleared when `setToolProgress([])` is called on new message)

## Acceptance criteria
- [x] `tool_end` SSE contains `field` and `value` for `save_profile_field` and `update_preference`
- [x] Regular tools (search_reddit, add_to_history) don't include `field`/`value`
- [x] Profile edit chip rendered in chat for matching tool calls
- [x] [Edit] opens inline form; Confirm calls `PATCH /profile`; dismiss closes without save
- [x] Chips are ephemeral (not persisted across session reload)
- [x] 3 tests in `tests/integration/test_profile_chip_payload.py`

## Test plan
- [ ] Chat in shopping mode; Claude calls `save_profile_field` — chip appears
- [ ] Click [Edit], change value, press OK — profile updated
- [ ] Click [Edit], press Escape/dismiss — no change
- [ ] Reload session — chip not shown (ephemeral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)